### PR TITLE
14 production company remove ownermanager

### DIFF
--- a/src/main/java/com/group16b/ApplicationLayer/UserService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/UserService.java
@@ -531,7 +531,7 @@ public class UserService {
 			return Result.makeFail("An unexpected error occurred: " + e.getMessage());
 		}
 	}
-		public Result<Boolean> removeOwnerManager(int targetID, int companyID, String sessionToken) {
+	public Result<Boolean> removeOwnerManager(int targetID, int companyID, String sessionToken) {
 		try {
 			//auth
 			logger.info("Verifying session token for removing manager with id {0} for company {1}.", targetID,companyID);
@@ -572,13 +572,13 @@ public class UserService {
 				logger.warn("User {0} isn't above target {1} in the hierarchy tree in company {2}, thus he cant remove them",userID,targetID,companyID);
 				return Result.makeFail("User didn't apoint target so no permission to remove");
 			}
-			companyHierarchyDomainService.removeUserFromCompany(user, companyID);
+			companyHierarchyDomainService.removeUserFromCompany(target, companyID);
 			logger.info("target {0} was removed from company {1} by user {2}",targetID,companyID,userID);
 			return Result.makeOk(true);
 
 
 		} catch (IllegalArgumentException | IllegalStateException e) {
-			logger.error("Failed to forfeit ownership: " + e.getMessage());
+			logger.error("Failed to remove manager from company: " + e.getMessage());
 			return Result.makeFail(e.getMessage());
 		} catch (JwtException e) {
 			logger.error("JWT authentication error during forfeitng ownership: " + e.getMessage());

--- a/src/main/java/com/group16b/ApplicationLayer/UserService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/UserService.java
@@ -493,16 +493,14 @@ public class UserService {
 			}
 			int userID=authenticationService.extractIdFromUserToken(sessionToken);
 			User user = userRepository.getUserByID(userID);
-
+			if (user == null) {
+				logger.warn("User with ID {0} not found for forfeiting ownership", userID);
+				return Result.makeFail("User not found.");
+			}
+			logger.info("Session token verified successfully.");
 			Integer assignerID;
 			synchronized(lock)
 			{
-				if (user == null) {
-					logger.warn("User with ID {0} not found for forfeiting ownership", userID);
-					return Result.makeFail("User not found.");
-				}
-				logger.info("Session token verified successfully.");
-
 				if(!user.isOwnerOfCompany(companyID))
 				{
 					logger.warn("user {0} is not owner for comapny {1}, thus he cant forfeit his ownership there",userID,companyID);
@@ -532,6 +530,7 @@ public class UserService {
 		}
 	}
 	public Result<Boolean> removeOwnerManager(int targetID, int companyID, String sessionToken) {
+		Object lock = getCompanyLock(companyID);
 		try {
 			//auth
 			logger.info("Verifying session token for removing manager with id {0} for company {1}.", targetID,companyID);
@@ -546,13 +545,6 @@ public class UserService {
 				return Result.makeFail("User not found.");
 			}
 			logger.info("Session token verified successfully.");
-
-			if(!user.isOwnerOfCompany(companyID))
-			{
-				logger.warn("user {0} is not owner for comapny {1}, thus he cant remove manager there",userID,companyID);
-				return Result.makeFail("user is not owner");
-			}
-			
 			logger.info("retrieving target user {0} to remove manager from company {1} by user {2}",targetID,companyID,userID);
 			User target=userRepository.getUserByID(targetID);
 			if(target==null)
@@ -560,19 +552,27 @@ public class UserService {
 				logger.warn("target user {0} was not found to remove him from the compny {1} by user {2}.",targetID,companyID,userID);
 				return Result.makeFail("target user was not found");
 			}
-
-			if(target.getRole(companyID)==null)
+			synchronized(lock)
 			{
-				logger.warn("target user {0} is not personal in the company {1} to remove them by user {2}",targetID,companyID,userID);
-				return Result.makeFail("target user is not personal in company");
-			}
+				if(!user.isOwnerOfCompany(companyID))
+				{
+					logger.warn("user {0} is not owner for comapny {1}, thus he cant remove manager there",userID,companyID);
+					return Result.makeFail("user is not owner");
+				}
 
-			if(!companyHierarchyDomainService.isManagerUnderOwnerTreeTraversal(target, user, companyID))
-			{
-				logger.warn("User {0} isn't above target {1} in the hierarchy tree in company {2}, thus he cant remove them",userID,targetID,companyID);
-				return Result.makeFail("User didn't apoint target so no permission to remove");
+				if(target.getRole(companyID)==null)
+				{
+					logger.warn("target user {0} is not personal in the company {1} to remove them by user {2}",targetID,companyID,userID);
+					return Result.makeFail("target user is not personal in company");
+				}
+
+				if(!companyHierarchyDomainService.isManagerUnderOwnerTreeTraversal(target, user, companyID))
+				{
+					logger.warn("User {0} isn't above target {1} in the hierarchy tree in company {2}, thus he cant remove them",userID,targetID,companyID);
+					return Result.makeFail("User didn't apoint target so no permission to remove");
+				}
+				companyHierarchyDomainService.removeUserFromCompany(target, companyID);
 			}
-			companyHierarchyDomainService.removeUserFromCompany(target, companyID);
 			logger.info("target {0} was removed from company {1} by user {2}",targetID,companyID,userID);
 			return Result.makeOk(true);
 

--- a/src/main/java/com/group16b/ApplicationLayer/UserService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/UserService.java
@@ -343,6 +343,7 @@ public class UserService {
 		}
 	}
 	public Result<Boolean> acceptInviteToCompany(int companyID, int assignerID, String sessionToken) {
+		Object companyLock = getCompanyLock(companyID);
 		try {
 			//auth
 			logger.info("Verifying session token for accepting invite assignment to company {0} by assigner {2}.", companyID, assignerID);
@@ -352,6 +353,11 @@ public class UserService {
 			}
 			int userID=authenticationService.extractIdFromUserToken(sessionToken);
 			User user = userRepository.getUserByID(userID);
+			if(user==null)
+			{
+				logger.warn("user {0} was not found, maybe deleted",userID);
+				return Result.makeFail("user not found");
+			}
 			logger.info("Session token verified successfully.");
 
 			User assigner = userRepository.getUserByID(assignerID);
@@ -359,26 +365,30 @@ public class UserService {
 				logger.warn("Assigner user with ID {0} not found for accepting invite assignment to company {1} by user {2}.", assignerID, companyID, userID);
 				return Result.makeFail("Assigner user not found.");
 			}
-			if(!assigner.isOwnerOfCompany(companyID))
+			synchronized(companyLock)
 			{
-				logger.warn("Assigner user with ID {0} does not have permission to assign roles for company {1} for accepting invite assignment to company {1} by user {2}.", assignerID, companyID, userID);
-				return Result.makeFail("Assigner user does not have permission to assign roles for this company.");
-			}
-			
-			//check that invite exists and accept it
-			logger.info("accepting invite assignment invite for company {0} by user {1} and assigner {2}.", companyID, userID, assignerID);
-			user.getUserInvitesLock().lock();
-			try {
-				user.acceptInvite(companyID, assignerID);
-				assigner.addAssignee(companyID, (Manager) user.getRole(companyID));
-				logger.info("Invite assignment invite accepted successfully for company {0} by user {1} and assigner {2}.", companyID, userID, assignerID);
-			} 
-			catch (IllegalArgumentException e) {
-				logger.error("Failed to accept invite: " + e.getMessage());
-				return Result.makeFail(e.getMessage());
-			}
-			finally {
-				user.getUserInvitesLock().unlock();
+				if(!assigner.isOwnerOfCompany(companyID))
+				{
+					logger.warn("Assigner user with ID {0} does not have permission to assign roles for company {1} for accepting invite assignment to company {1} by user {2}.", assignerID, companyID, userID);
+					return Result.makeFail("Assigner user does not have permission to assign roles for this company.");
+				}
+				
+				//check that invite exists and accept it
+				logger.info("accepting invite assignment invite for company {0} by user {1} and assigner {2}.", companyID, userID, assignerID);
+				user.getUserInvitesLock().lock();
+				try {
+					user.acceptInvite(companyID, assignerID);
+					assigner.addAssignee(companyID, (Manager) user.getRole(companyID));
+					logger.info("Invite assignment invite accepted successfully for company {0} by user {1} and assigner {2}.", companyID, userID, assignerID);
+				} 
+				catch (IllegalArgumentException e) {
+					logger.error("Failed to accept invite: " + e.getMessage());
+					user.removeRole(companyID);//just in case
+					return Result.makeFail(e.getMessage());
+				}
+				finally {
+					user.getUserInvitesLock().unlock();
+				}
 			}
 			logger.info("user {0} have succesfully accepted an invite to company {1} by user {2}",userID,companyID,assignerID);
 			return Result.makeOk(true);
@@ -414,14 +424,14 @@ public class UserService {
 			}
 
 			//check that invite exists and reject it
-			logger.info("rejecting invite assignment invite for company {0} by user {1} and assigner {2}.", companyID, userID, assignerID);
+			logger.info("rejecting invite assignment for company {0} by user {1} and assigner {2}.", companyID, userID, assignerID);
 			user.getUserInvitesLock().lock();
 			try {
 				user.rejectInvite(companyID, assignerID);
-				logger.info("Invite assignment invite rejected successfully for company {0} by user {1} and assigner {2}.", companyID, userID, assignerID);
+				logger.info("invite rejected successfully for company {0} by user {1} and assigner {2}.", companyID, userID, assignerID);
 			} 
 			catch (IllegalArgumentException e) {
-				logger.error("Failed to add invite assignment invite: " + e.getMessage());
+				logger.error("Failed to reject invite: " + e.getMessage());
 				return Result.makeFail(e.getMessage());
 			}
 			finally {

--- a/src/main/java/com/group16b/ApplicationLayer/UserService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/UserService.java
@@ -264,6 +264,7 @@ public class UserService {
 			finally {
 				targetUser.getUserInvitesLock().unlock();
 			}
+			logger.info("user {0} have been succesfully invited to be an owner in company {1} by user {2}",targetID,companyID,userID);
 			return Result.makeOk(true);
 
 		} catch (IllegalArgumentException e) {
@@ -321,6 +322,7 @@ public class UserService {
 			finally {
 				targetUser.getUserInvitesLock().unlock();
 			}
+			logger.info("user {0} have been succesfully invited to be a manager in company {1} by user {2}",targetID,companyID,userID);
 			return Result.makeOk(true);
 
 		} catch (IllegalArgumentException e) {
@@ -375,7 +377,7 @@ public class UserService {
 			finally {
 				user.getUserInvitesLock().unlock();
 			}
-
+			logger.info("user {0} have succesfully accepted an invite to company {1} by user {2}",userID,companyID,assignerID);
 			return Result.makeOk(true);
 		} catch (IllegalArgumentException e) {
 			logger.error("Failed to accepting invite: " + e.getMessage());
@@ -422,7 +424,7 @@ public class UserService {
 			finally {
 				user.getUserInvitesLock().unlock();
 			}
-
+			logger.info("user {0} have succesfully rejected an invite to company {1} by user {2}",userID,companyID,assignerID);
 			return Result.makeOk(true);
 		} catch (IllegalArgumentException e) {
 			logger.error("Failed to reject invite: " + e.getMessage());
@@ -498,7 +500,6 @@ public class UserService {
 				logger.warn("user {0} is not owner for comapny {1}, thus he cant forfeit his ownership there",userID,companyID);
 				return Result.makeFail("user is not owner");
 			}
-			Manager userManager=(Manager)user.getRole(companyID);
 
 			Integer assignerID=user.getParentIDForCompany(companyID);
 			if(assignerID==null)
@@ -510,13 +511,13 @@ public class UserService {
 			User assigner=userRepository.getUserByID(assignerID);
 			if(assigner==null)
 			{
-				logger.error("assigner want found to remove the user from his asignee list in forfeit ownership");
+				logger.error("assigner wasnt found to remove the user from his asignee list in forfeit ownership");
 				return Result.makeFail("assigner wasnt found");
 			}
-			Owner assignerOwner=(Owner)assigner.getRole(companyID);
 
-			assignerOwner.removeManager(userManager);
-			user.removeRole(companyID);
+			companyHierarchyDomainService.removeUserFromCompany(user, companyID);
+
+			logger.info("user {0} has succesfuly forfeited its role in company {1}, thus removing itself from the children of its company parent {2}",userID,companyID,assignerID);
 			return Result.makeOk(true);
 
 		} catch (IllegalArgumentException | IllegalStateException e) {
@@ -530,5 +531,61 @@ public class UserService {
 			return Result.makeFail("An unexpected error occurred: " + e.getMessage());
 		}
 	}
+		public Result<Boolean> removeOwnerManager(int targetID, int companyID, String sessionToken) {
+		try {
+			//auth
+			logger.info("Verifying session token for removing manager with id {0} for company {1}.", targetID,companyID);
+			if (!authenticationService.authenticate(sessionToken)) {
+				logger.warn("Invalid session token provided for removing manager with id {0} for company {1}.", targetID,companyID);
+				return Result.makeFail("Invalid session token.");
+			}
+			int userID=authenticationService.extractIdFromUserToken(sessionToken);
+			User user = userRepository.getUserByID(userID);
+			if (user == null) {
+				logger.warn("User with ID {0} not found for removing manager", userID);
+				return Result.makeFail("User not found.");
+			}
+			logger.info("Session token verified successfully.");
 
+			if(!user.isOwnerOfCompany(companyID))
+			{
+				logger.warn("user {0} is not owner for comapny {1}, thus he cant remove manager there",userID,companyID);
+				return Result.makeFail("user is not owner");
+			}
+			
+			logger.info("retrieving target user {0} to remove manager from company {1} by user {2}",targetID,companyID,userID);
+			User target=userRepository.getUserByID(targetID);
+			if(target==null)
+			{
+				logger.warn("target user {0} was not found to remove him from the compny {1} by user {2}.",targetID,companyID,userID);
+				return Result.makeFail("target user was not found");
+			}
+
+			if(target.getRole(companyID)==null)
+			{
+				logger.warn("target user {0} is not personal in the company {1} to remove them by user {2}",targetID,companyID,userID);
+				return Result.makeFail("target user is not personal in company");
+			}
+
+			if(!companyHierarchyDomainService.isManagerUnderOwnerTreeTraversal(target, user, companyID))
+			{
+				logger.warn("User {0} isn't above target {1} in the hierarchy tree in company {2}, thus he cant remove them",userID,targetID,companyID);
+				return Result.makeFail("User didn't apoint target so no permission to remove");
+			}
+			companyHierarchyDomainService.removeUserFromCompany(user, companyID);
+			logger.info("target {0} was removed from company {1} by user {2}",targetID,companyID,userID);
+			return Result.makeOk(true);
+
+
+		} catch (IllegalArgumentException | IllegalStateException e) {
+			logger.error("Failed to forfeit ownership: " + e.getMessage());
+			return Result.makeFail(e.getMessage());
+		} catch (JwtException e) {
+			logger.error("JWT authentication error during forfeitng ownership: " + e.getMessage());
+			return Result.makeFail("Authentication failed: " + e.getMessage());
+		} catch (Exception e) {
+			logger.error("Unexpected error during forfeiting ownership: " + e.getMessage());
+			return Result.makeFail("An unexpected error occurred: " + e.getMessage());
+		}
+	}
 }

--- a/src/main/java/com/group16b/ApplicationLayer/UserService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/UserService.java
@@ -3,6 +3,7 @@ package com.group16b.ApplicationLayer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,8 @@ public class UserService {
 	private final IUserRepository userRepository;
 
 	private final CompanyHierarchyDomainService companyHierarchyDomainService;
+
+	private final ConcurrentHashMap<Integer, Object> companyLocks = new ConcurrentHashMap<>();
 
 	public UserService(IAuthenticationService authenticationService, IUserRepository userRepository, CompanyHierarchyDomainService companyHierarchyDomainService) {
 		this.authenticationService = authenticationService;
@@ -480,6 +483,7 @@ public class UserService {
 	}
 
 	public Result<Boolean> forfeitOwnership(int companyID, String sessionToken) {
+		Object lock = getCompanyLock(companyID);
 		try {
 			//auth
 			logger.info("Verifying session token for forfeiten ownership for company {0}.", companyID);
@@ -489,34 +493,30 @@ public class UserService {
 			}
 			int userID=authenticationService.extractIdFromUserToken(sessionToken);
 			User user = userRepository.getUserByID(userID);
-			if (user == null) {
-				logger.warn("User with ID {0} not found for forfeiting ownership", userID);
-				return Result.makeFail("User not found.");
-			}
-			logger.info("Session token verified successfully.");
 
-			if(!user.isOwnerOfCompany(companyID))
+			Integer assignerID;
+			synchronized(lock)
 			{
-				logger.warn("user {0} is not owner for comapny {1}, thus he cant forfeit his ownership there",userID,companyID);
-				return Result.makeFail("user is not owner");
+				if (user == null) {
+					logger.warn("User with ID {0} not found for forfeiting ownership", userID);
+					return Result.makeFail("User not found.");
+				}
+				logger.info("Session token verified successfully.");
+
+				if(!user.isOwnerOfCompany(companyID))
+				{
+					logger.warn("user {0} is not owner for comapny {1}, thus he cant forfeit his ownership there",userID,companyID);
+					return Result.makeFail("user is not owner");
+				}
+
+				assignerID=user.getParentIDForCompany(companyID);
+				if(assignerID==null)
+				{
+					logger.warn("user {0} is founder and thus can't leave the company {1}",userID, companyID);
+					return Result.makeFail("founder cant leave company");
+				}
+				companyHierarchyDomainService.removeUserFromCompany(user, companyID);
 			}
-
-			Integer assignerID=user.getParentIDForCompany(companyID);
-			if(assignerID==null)
-			{
-				logger.warn("user {0} is founder and thus can't leave the company {1}",userID, companyID);
-				return Result.makeFail("founder cant leave company");
-			}
-
-			User assigner=userRepository.getUserByID(assignerID);
-			if(assigner==null)
-			{
-				logger.error("assigner wasnt found to remove the user from his asignee list in forfeit ownership");
-				return Result.makeFail("assigner wasnt found");
-			}
-
-			companyHierarchyDomainService.removeUserFromCompany(user, companyID);
-
 			logger.info("user {0} has succesfuly forfeited its role in company {1}, thus removing itself from the children of its company parent {2}",userID,companyID,assignerID);
 			return Result.makeOk(true);
 
@@ -587,5 +587,10 @@ public class UserService {
 			logger.error("Unexpected error during forfeiting ownership: " + e.getMessage());
 			return Result.makeFail("An unexpected error occurred: " + e.getMessage());
 		}
+	}
+
+
+	private Object getCompanyLock(int companyID) {
+		return companyLocks.computeIfAbsent(companyID, id -> new Object());
 	}
 }

--- a/src/main/java/com/group16b/DomainLayer/DomainServices/CompanyHierarchyDomainService.java
+++ b/src/main/java/com/group16b/DomainLayer/DomainServices/CompanyHierarchyDomainService.java
@@ -23,6 +23,10 @@ public class CompanyHierarchyDomainService {
         {//save us runtime by checking this before traversing the tree
             return false;
         }
+        if(manager.getUserID()==owner.getUserID())
+        {
+            return false;
+        }
         //traverse upwards in search of owner
         User current = manager;
         while (current != null) {
@@ -36,6 +40,19 @@ public class CompanyHierarchyDomainService {
             current = userRepository.getUserByID(parentID);
         }
         return false;
+    }
+
+    //will remove a user from a company irarchy
+    //PRECONDITIONS: user is a manager in the company, user is not owner of the company
+    //this should only be called after ensuring that the callee have high enough clearance
+    public void removeUserFromCompany(User user, int companyID)
+    {   
+        int parentID= user.getParentIDForCompany(companyID);
+        User parent=userRepository.getUserByID(parentID);
+        Manager userRole=(Manager)user.getRole(companyID);
+        Owner parentRole=(Owner)parent.getRole(companyID);
+        parentRole.removeManager(userRole);
+        user.removeRole(companyID);
     }
 
 }

--- a/src/test/java/com/group16b/ServiceLayer/UserServiceTests.java
+++ b/src/test/java/com/group16b/ServiceLayer/UserServiceTests.java
@@ -433,6 +433,124 @@ public class UserServiceTests {
        
         assertFalse(userService.forfeitOwnership( companyID, "").isSuccess());
     }
+
+    //------------------------------------------------------------------------------------------
+    //     REMOVE PERSONAL FROM COMPANY TESTS
+    //------------------------------------------------------------------------------------------
+
+    @Test
+    void testRemoveManagerFromCompanySuccess()
+    {
+        int userID = 1;
+        int companyID = 1;
+        int targetID = 2;
+        User mockUser = mock(User.class);
+        User mockTarget=mock(User.class);
+        Manager mockRole=mock(Manager.class);
+        when(mockAuthService.authenticate(anyString())).thenReturn(true);
+        when(mockAuthService.extractIdFromUserToken(anyString())).thenReturn(userID);
+        when(mockUserRepository.getUserByID(userID)).thenReturn(mockUser);
+        when(mockUserRepository.getUserByID(targetID)).thenReturn(mockTarget);
+        when(mockUserRepository.userExists(targetID)).thenReturn(true);
+        when(mockUser.isOwnerOfCompany(companyID)).thenReturn(true);
+        when(mockTarget.getParentIDForCompany(companyID)).thenReturn(userID);
+        when(mockTarget.getRole(companyID)).thenReturn(mockRole);
+        when(mockCompanyHierarchyDomainService.isManagerUnderOwnerTreeTraversal(mockTarget, mockUser, companyID)).thenReturn(true);
+        doNothing().when(mockCompanyHierarchyDomainService).removeUserFromCompany(mockTarget, companyID);
+
+        assertTrue(userService.removeOwnerManager(targetID, companyID, "").isSuccess());
+    }
+
+    @Test
+    void testRemoveManagerFromCompanyTargetNotUnderFail()
+    {
+        int userID = 1;
+        int companyID = 1;
+        int targetID = 2;
+        User mockUser = mock(User.class);
+        User mockTarget=mock(User.class);
+        Manager mockRole=mock(Manager.class);
+        when(mockAuthService.authenticate(anyString())).thenReturn(true);
+        when(mockAuthService.extractIdFromUserToken(anyString())).thenReturn(userID);
+        when(mockUserRepository.getUserByID(userID)).thenReturn(mockUser);
+        when(mockUserRepository.getUserByID(targetID)).thenReturn(mockTarget);
+        when(mockUserRepository.userExists(targetID)).thenReturn(true);
+        when(mockUser.isOwnerOfCompany(companyID)).thenReturn(true);
+        when(mockTarget.getParentIDForCompany(companyID)).thenReturn(userID);
+        when(mockTarget.getRole(companyID)).thenReturn(mockRole);
+        when(mockCompanyHierarchyDomainService.isManagerUnderOwnerTreeTraversal(mockTarget, mockUser, companyID)).thenReturn(false);
+        doNothing().when(mockCompanyHierarchyDomainService).removeUserFromCompany(mockTarget, companyID);
+
+        assertFalse(userService.removeOwnerManager(targetID, companyID, "").isSuccess());
+    }
+
+    @Test
+    void testRemoveManagerFromCompanyUserNotOwnerFail()
+    {
+        int userID = 1;
+        int companyID = 1;
+        int targetID = 2;
+        User mockUser = mock(User.class);
+        User mockTarget=mock(User.class);
+        Manager mockRole=mock(Manager.class);
+        when(mockAuthService.authenticate(anyString())).thenReturn(true);
+        when(mockAuthService.extractIdFromUserToken(anyString())).thenReturn(userID);
+        when(mockUserRepository.getUserByID(userID)).thenReturn(mockUser);
+        when(mockUserRepository.getUserByID(targetID)).thenReturn(mockTarget);
+        when(mockUserRepository.userExists(targetID)).thenReturn(true);
+        when(mockUser.isOwnerOfCompany(companyID)).thenReturn(false);
+        when(mockTarget.getParentIDForCompany(companyID)).thenReturn(userID);
+        when(mockTarget.getRole(companyID)).thenReturn(mockRole);
+        when(mockCompanyHierarchyDomainService.isManagerUnderOwnerTreeTraversal(mockTarget, mockUser, companyID)).thenReturn(true);
+        doNothing().when(mockCompanyHierarchyDomainService).removeUserFromCompany(mockTarget, companyID);
+
+        assertFalse(userService.removeOwnerManager(targetID, companyID, "").isSuccess());
+    }
     
+    @Test
+    void testRemoveManagerFromCompanyTargetNotPersonalFail()
+    {
+        int userID = 1;
+        int companyID = 1;
+        int targetID = 2;
+        User mockUser = mock(User.class);
+        User mockTarget=mock(User.class);
+        Manager mockRole=mock(Manager.class);
+        when(mockAuthService.authenticate(anyString())).thenReturn(true);
+        when(mockAuthService.extractIdFromUserToken(anyString())).thenReturn(userID);
+        when(mockUserRepository.getUserByID(userID)).thenReturn(mockUser);
+        when(mockUserRepository.getUserByID(targetID)).thenReturn(mockTarget);
+        when(mockUserRepository.userExists(targetID)).thenReturn(true);
+        when(mockUser.isOwnerOfCompany(companyID)).thenReturn(true);
+        when(mockTarget.getParentIDForCompany(companyID)).thenReturn(userID);
+        when(mockTarget.getRole(companyID)).thenReturn(null);
+        when(mockCompanyHierarchyDomainService.isManagerUnderOwnerTreeTraversal(mockTarget, mockUser, companyID)).thenReturn(true);
+        doNothing().when(mockCompanyHierarchyDomainService).removeUserFromCompany(mockTarget, companyID);
+
+        assertFalse(userService.removeOwnerManager(targetID, companyID, "").isSuccess());
+    }
+
+    @Test
+    void testRemoveManagerFromCompanyAuthFail()
+    {
+        int userID = 1;
+        int companyID = 1;
+        int targetID = 2;
+        User mockUser = mock(User.class);
+        User mockTarget=mock(User.class);
+        Manager mockRole=mock(Manager.class);
+        when(mockAuthService.authenticate(anyString())).thenReturn(false);
+        when(mockAuthService.extractIdFromUserToken(anyString())).thenReturn(userID);
+        when(mockUserRepository.getUserByID(userID)).thenReturn(mockUser);
+        when(mockUserRepository.getUserByID(targetID)).thenReturn(mockTarget);
+        when(mockUserRepository.userExists(targetID)).thenReturn(true);
+        when(mockUser.isOwnerOfCompany(companyID)).thenReturn(true);
+        when(mockTarget.getParentIDForCompany(companyID)).thenReturn(userID);
+        when(mockTarget.getRole(companyID)).thenReturn(mockRole);
+        when(mockCompanyHierarchyDomainService.isManagerUnderOwnerTreeTraversal(mockTarget, mockUser, companyID)).thenReturn(true);
+        doNothing().when(mockCompanyHierarchyDomainService).removeUserFromCompany(mockTarget, companyID);
+
+        assertFalse(userService.removeOwnerManager(targetID, companyID, "").isSuccess());
+    }
 
 }


### PR DESCRIPTION
added the ability to remove an assigned owner/manager
added tests
Added locking to all the use cases that modify the hierarchy tree
correctness for the locking of acceptInvite is heavily reliant on how delete user will be implemented, as it will be correct only if delete user will gracefully remove the user from all the companies he is in while using the same locks
ALSO DONT forget to close the other remove manager ticket as its a duplicate of this ticket