### PR TITLE
179 productioncompanyservice tests refactor

### DIFF
--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -126,6 +126,7 @@ public class ProductionCompanyService {
             .collect(Collectors.toSet());
     }
 
+    //duplication for efficency, instead of traversing the stream twice, traverse once and filter by permissions, then get the orders for those events
     private Set<Integer> getManagedCompanyEventIDs(ProductionCompany company, String userID)
     {
         if(company.isFounder(userID))//divert for efficency if founder, as they have access to all events of the company

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -126,6 +126,7 @@ public class ProductionCompanyService {
                 .collect(Collectors.toSet());
         return orderRepo.getAll().stream()
                     .filter(order -> companyEventIDs.contains(order.getEventId()))
+                    .filter(Order::isCompleted)
                     .toList();
     }
 

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -131,7 +131,7 @@ public class ProductionCompanyService {
         if(company.isFounder(userID))//divert for efficency if founder, as they have access to all events of the company
             return getCompanyEventIDs(company.getProductionCompanyID());
 
-        Set<String> allowedManagers =new HashSet<>(company.getAllSubordinates(userID));
+        Set<String> allowedManagers =new HashSet<>(company.getOwnershipDescendants(userID));
 
         allowedManagers.add(userID);
 

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -1,5 +1,6 @@
 package com.group16b.ApplicationLayer;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -56,9 +57,9 @@ public class ProductionCompanyService {
             
 
             logger.info("ProductionCompanyService.viewSalesHistory: collecting all orders for the company {} events",productionCompanyID);
-            List<OrderDTO> orderDTOs =getAllCompletedCompanyOrders(productionCompanyID).stream()
-                    .map(OrderDTO::new)
-                    .toList();
+            List<OrderDTO> orderDTOs =getCompletedOrdersByEventIDs(getCompanyEventIDs(productionCompanyID)).stream()
+                .map(OrderDTO::new)
+                .toList();
 
             logger.info("ProductionCompanyService.viewSalesHistory: succesfully collected all orders.");
             return Result.makeOk(orderDTOs);
@@ -89,7 +90,7 @@ public class ProductionCompanyService {
             company.validateUserPermissions(userID,ManagerPermissions.SALES_REPORT);
 
             logger.info("ProductionCompanyService.displayTotalRevenue: calculating total revenue for company {}",productionCompanyID);
-            double totalRevenue = getAllRevenue(getAllCompletedCompanyOrders(productionCompanyID));
+            double totalRevenue = getAllRevenue(getCompletedOrdersByEventIDs(getManagedCompanyEventIDs(company,userID)));
 
             logger.info("ProductionCompanyService.displayTotalRevenue: successfuly calculated total revenue for company {}.",productionCompanyID);
             return Result.makeOk(totalRevenue);
@@ -112,22 +113,48 @@ public class ProductionCompanyService {
     }
 
     //gets all orders for the company
-    private List<Order> getAllCompletedCompanyOrders(int companyID)
+    private Set<Integer> getCompanyEventIDs(int companyID)
     {
-        Set<Integer> companyEventIDs =
-                eventRepo.searchEvents(
-                    null, null, null, null,
-                    null, null,
-                    null, null,
-                    null,
-                    List.of(companyID)
-                ).stream()
-                .map(Event::getEventID)
-                .collect(Collectors.toSet());
+        return eventRepo.searchEvents(
+                null, null, null, null,
+                null, null,
+                null, null,
+                null,
+                List.of(companyID)
+            ).stream()
+            .map(Event::getEventID)
+            .collect(Collectors.toSet());
+    }
+
+    private Set<Integer> getManagedCompanyEventIDs(ProductionCompany company, String userID)
+    {
+        if(company.isFounder(userID))//divert for efficency if founder, as they have access to all events of the company
+            return getCompanyEventIDs(company.getProductionCompanyID());
+
+        Set<String> allowedManagers =new HashSet<>(company.getAllSubordinates(userID));
+
+        allowedManagers.add(userID);
+
+        return eventRepo.searchEvents(
+                null, null, null, null,
+                null, null,
+                null, null,
+                null,
+                List.of(company.getProductionCompanyID())
+            ).stream()
+            .filter(event ->
+                allowedManagers.contains(event.getOwnerId())
+            )
+            .map(Event::getEventID)
+            .collect(Collectors.toSet());
+    }
+
+    private List<Order> getCompletedOrdersByEventIDs(Set<Integer> eventIDs)
+    {
         return orderRepo.getAll().stream()
-                    .filter(order -> companyEventIDs.contains(order.getEventId()))
-                    .filter(Order::isCompleted)
-                    .toList();
+                .filter(Order::isCompleted)
+                .filter(order -> eventIDs.contains(order.getEventId()))
+                .toList();
     }
 
     private double getAllRevenue(List<Order> orders) 

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -132,9 +132,10 @@ public class ProductionCompanyService {
         if(company.isFounder(userID))//divert for efficency if founder, as they have access to all events of the company
             return getCompanyEventIDs(company.getProductionCompanyID());
 
-        Set<String> allowedManagers =new HashSet<>(company.getOwnershipDescendants(userID));
+        //since in the current model, only ownners can create event, directly gather them for optimization
+        Set<String> allowedManager =new HashSet<>(company.getAllSubordinates(userID));
 
-        allowedManagers.add(userID);
+        allowedManager.add(userID);
 
         return eventRepo.searchEvents(
                 null, null, null, null,
@@ -144,7 +145,7 @@ public class ProductionCompanyService {
                 List.of(company.getProductionCompanyID())
             ).stream()
             .filter(event ->
-                allowedManagers.contains(event.getOwnerId())
+                allowedManager.contains(event.getOwnerId())
             )
             .map(Event::getEventID)
             .collect(Collectors.toSet());

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
@@ -239,7 +239,7 @@ public class ProductionCompany {
         MembershipNode node=membersNodes.get(userID);
         if(node==null || !(node.getPermissions().contains(perm)))
         {
-            throw new IllegalArgumentException("user "+userID+" dont have high enough permissions in company "+this.productionCompanyID);
+            throw new IllegalArgumentException("user "+userID+" dont have correct permissions in company "+this.productionCompanyID);
         }
     }
 

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
@@ -2,6 +2,7 @@ package com.group16b.DomainLayer.ProductionCompany;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -11,7 +12,6 @@ import com.group16b.DomainLayer.Policies.DiscountPolicy.DiscountPolicy;
 import com.group16b.DomainLayer.Policies.PurchasePolicy.PurchasePolicy;
 import com.group16b.DomainLayer.ProductionCompany.membership.HierarchyNodeData;
 import com.group16b.DomainLayer.ProductionCompany.membership.MembershipNode;
-import com.group16b.DomainLayer.User.User;
 import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
 import com.group16b.DomainLayer.ProductionCompany.membership.RoleType;
 
@@ -24,6 +24,7 @@ public class ProductionCompany {
 
     private final HashMap<String, MembershipNode> membersNodes=new HashMap<>();
     private final HashMap<InviteKey, MembershipNode> invites= new HashMap<>();
+    private final HashMap<String, Set<String>> childrenByUser = new HashMap<>();
 
     public ProductionCompany(ProductionCompany other)
     {
@@ -44,6 +45,7 @@ public class ProductionCompany {
                     new MembershipNode(entry.getValue())
             );
         }
+        childrenByUser.putAll(other.childrenByUser);
     }
     public ProductionCompany(int id, String name, double rating, String founderID)
     {
@@ -160,6 +162,7 @@ public class ProductionCompany {
         }
 
         membersNodes.put(targetID, invite);
+        addChild(assignerID, targetID);
 
         RoleType acceptedRole = invite.getRoleType();
 
@@ -243,41 +246,34 @@ public class ProductionCompany {
         }
     }
 
-    public List<String> getDirectSubordinates(String userID)
-    {
+    public List<String> getAllSubordinates(String userID) {
         List<String> result = new ArrayList<>();
-
-        for (Map.Entry<String, MembershipNode> entry : membersNodes.entrySet())
-        {
-            MembershipNode node = entry.getValue();
-
-            if (node.getAssignerID() == userID)
-            {
-                result.add(entry.getKey());
-            }
-        }
-
-        return result;
-    }
-
-    public List<String> getAllSubordinates(String userID)
-    {
-        List<String> result = new ArrayList<>();
-
         collectSubordinates(userID, result);
-
         return result;
     }
 
-    private void collectSubordinates(String userID, List<String> result)
+    private void collectSubordinates(String userID, List<String> result) {
+        for (String child : childrenByUser.getOrDefault(userID, Set.of())) {
+            result.add(child);
+            collectSubordinates(child, result);
+        }
+    }
+
+    public List<String> getOwnershipDescendants(String userID)
     {
-        List<String> directSubs = getDirectSubordinates(userID);
+        List<String> result = new ArrayList<>();
+        collectOwnershipDescendants(userID, result);
+        return result;
+    }
 
-        for (String subordinateID : directSubs)
-        {
-            result.add(subordinateID);
+    private void collectOwnershipDescendants(String userID, List<String> result) {
+        for (String child : childrenByUser.getOrDefault(userID, Set.of())) {
+            MembershipNode node = membersNodes.get(child);
 
-            collectSubordinates(subordinateID, result);
+            if (node != null && node.getRoleType() == RoleType.OWNER) {
+                result.add(child);
+                collectOwnershipDescendants(child, result);
+            }
         }
     }
 
@@ -306,23 +302,25 @@ public class ProductionCompany {
         if (node == null) return;
 
         String parentID = node.getAssignerID();
+        childrenByUser.get(parentID).remove(userID);
 
-        // reparent children
-        for (MembershipNode child : membersNodes.values()) {
-            if (isFounder(child.getUserID())){
-                continue;
-            }
-            if (child.getAssignerID().equals(userID)) {
-                child.setAssignerID(parentID);
+        Set<String> children = new HashSet<>(childrenByUser.getOrDefault(userID, Set.of()));
+        for (String child : children) {
+            MembershipNode childNode = membersNodes.get(child);
+            if (childNode != null) {
+                childNode.setAssignerID(parentID);
+                addChild(parentID, child);
             }
         }
+
+        childrenByUser.remove(userID);
 
         // remove user
         membersNodes.remove(userID);
 
         //remove all retaled invites
         invites.entrySet().removeIf(e ->
-            e.getKey().targetId == userID || e.getKey().assignerId==userID
+            e.getKey().targetId.equals(userID) || e.getKey().assignerId.equals(userID)
         );
     }
 
@@ -361,8 +359,8 @@ public class ProductionCompany {
             if (this == o) return true;
             if (!(o instanceof InviteKey)) return false;
             InviteKey other = (InviteKey) o;
-            return targetId == other.targetId &&
-                   assignerId == other.assignerId;
+            return targetId.equals(other.targetId) &&
+                   assignerId.equals(other.assignerId);
         }
 
         @Override
@@ -374,5 +372,9 @@ public class ProductionCompany {
     public void adminRemoveUser(String userID)
     {
         removeMember(userID);
+    }
+
+    private void addChild(String parent, String child) {
+        childrenByUser.computeIfAbsent(parent, k -> new HashSet<>()).add(child);
     }
 }

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
@@ -45,7 +45,12 @@ public class ProductionCompany {
                     new MembershipNode(entry.getValue())
             );
         }
-        childrenByUser.putAll(other.childrenByUser);
+        for (Map.Entry<String, Set<String>> entry : other.childrenByUser.entrySet()) {
+            this.childrenByUser.put(
+                entry.getKey(),
+                new HashSet<>(entry.getValue())
+            );
+        }
     }
     public ProductionCompany(int id, String name, double rating, String founderID)
     {
@@ -160,7 +165,13 @@ public class ProductionCompany {
         if (invite == null) {
             throw new IllegalArgumentException("Invite not found.");
         }
-
+        MembershipNode curRole = membersNodes.get(targetID);
+        if(curRole!=null)
+        {//remove from the child list of the parent
+            String parentID = curRole.getAssignerID();
+            if(parentID!=null)
+                childrenByUser.get(parentID).remove(targetID);
+        }
         membersNodes.put(targetID, invite);
         addChild(assignerID, targetID);
 
@@ -269,7 +280,6 @@ public class ProductionCompany {
     private void collectOwnershipDescendants(String userID, List<String> result) {
         for (String child : childrenByUser.getOrDefault(userID, Set.of())) {
             MembershipNode node = membersNodes.get(child);
-
             if (node != null && node.getRoleType() == RoleType.OWNER) {
                 result.add(child);
                 collectOwnershipDescendants(child, result);
@@ -304,7 +314,7 @@ public class ProductionCompany {
         String parentID = node.getAssignerID();
         childrenByUser.get(parentID).remove(userID);
 
-        Set<String> children = new HashSet<>(childrenByUser.getOrDefault(userID, Set.of()));
+        Set<String> children = childrenByUser.getOrDefault(userID, Set.of());
         for (String child : children) {
             MembershipNode childNode = membersNodes.get(child);
             if (childNode != null) {

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
@@ -72,10 +72,6 @@ public class ProductionCompany {
     {
         this.name=name;
     }
-    public List<User> getAssociatedUsers() {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getAssociatedUsers'");
-    }
 
     public long getVersion()
     {

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/membership/HierarchyNodeData.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/membership/HierarchyNodeData.java
@@ -2,9 +2,6 @@ package com.group16b.DomainLayer.ProductionCompany.membership;
 
 import java.util.Set;
 
-import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
-import com.group16b.DomainLayer.ProductionCompany.membership.RoleType;
-
 public class HierarchyNodeData {
     private final String userID;
     private final String parentID;

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/membership/MembershipNode.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/membership/MembershipNode.java
@@ -4,19 +4,15 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 
-
-import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
-import com.group16b.DomainLayer.ProductionCompany.membership.RoleType;
-
 public class MembershipNode {
     private String userID;
     private String assignerID;
     private RoleType roleType;
     private Set<ManagerPermissions> permissions;
 
-    private MembershipNode(String userID2, String assignerID, RoleType roleType, Set<ManagerPermissions> perms)
+    private MembershipNode(String userID, String assignerID, RoleType roleType, Set<ManagerPermissions> perms)
         {
-            this.userID=userID2;
+        this.userID=userID;
         this.assignerID=assignerID;
         this.roleType=roleType;
         this.permissions=new HashSet<>(perms);

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -485,6 +485,21 @@ public class ProductionCompanyServiceTests {
     }
 
     @Test
+    void displayTotalRevenue_ManagerWithNoEventsUnderHim_ReturnsAllCompanyRevenue() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                VALID_REVENUE_MANAGER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertTrue(result.isSuccess());
+
+        assertEquals(0.0, result.getValue());
+
+        assertRepositoriesUnchanged();
+    }
+
+    @Test
     void displayTotalRevenue_ManagerWithoutSalesPermission_ReturnsFailure() {
         Result<Double> result =
             service.displayTotalRevenue(

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -3,13 +3,13 @@ package com.group16b.ApplicationLayer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +44,8 @@ public class ProductionCompanyServiceTests {
 
     private ProductionCompany company1;
     private ProductionCompany company2;
+    private ProductionCompany companyWithNoEvents;
+    private ProductionCompany companyWithNoOrders;
     private User managerForHistory;
     private User managerForRevenue;
     private User managerWithNoUsefullPerms;
@@ -66,17 +68,19 @@ public class ProductionCompanyServiceTests {
     private final String OWNER_ID = "5";
     private final int COMPANY1_ID = 100;
     private final int COMPANY2_ID = 101;
+    private final int COMPANY_WITH_NO_EVENTS_ID = 102;
+    private final int COMPANY_WITH_NO_ORDERS_ID = 103; 
     private final int BAD_COMPANY_ID = 999;
     private final String BAD_USER_ID = "999";
-    private final String COMPANY1_ID_STRING = String.valueOf(COMPANY1_ID);
-    private final String COMPANY2_ID_STRING = String.valueOf(COMPANY2_ID);
     private final String FOUNDER_EMAIL="founder@example.com";
     private final String COMPANY1_NAME="Company1";
     private final String COMPANY2_NAME="Company2";
+    
 
     private Event company1Event1;
     private Event company1Event2;
     private Event company2Event1;
+    private Event companyWithNoOrdersEvent1;
 
     private Order company1Order1;
     private Order company1Order2;
@@ -154,6 +158,8 @@ public class ProductionCompanyServiceTests {
 
         company1 = createCompany(COMPANY1_ID, COMPANY1_NAME, FOUNDER_EMAIL);
         company2 = createCompany(COMPANY2_ID, COMPANY2_NAME, FOUNDER_EMAIL);
+        companyWithNoEvents = createCompany(COMPANY_WITH_NO_EVENTS_ID, "NoEventsCo", FOUNDER_EMAIL);
+        companyWithNoOrders = createCompany(COMPANY_WITH_NO_ORDERS_ID, "NoOrdersCo", FOUNDER_EMAIL);
 
         assignManagerToCompany(company1, MANAGER_FOR_HISTORY_ID, FOUNDER_EMAIL, Set.of(ManagerPermissions.VIEW_PURCHASE_HISTORY));
         assignOwnerToCompany(company1, OWNER_ID, FOUNDER_EMAIL);
@@ -162,14 +168,18 @@ public class ProductionCompanyServiceTests {
 
         companyRepo.save(company1);
         companyRepo.save(company2);
+        companyRepo.save(companyWithNoEvents);
+        companyRepo.save(companyWithNoOrders);
 
         company1Event1 = createEvent(1, COMPANY1_ID);
         company1Event2 = createEvent(2, COMPANY1_ID);
         company2Event1 = createEvent(3, COMPANY2_ID);
+        companyWithNoOrdersEvent1 = createEvent(4, COMPANY_WITH_NO_ORDERS_ID);
 
         eventRepo.save(company1Event1);
         eventRepo.save(company1Event2);
         eventRepo.save(company2Event1);
+        eventRepo.save(companyWithNoOrdersEvent1);
 
         company1Order1 = createCompletedOrder(company1Event1.getEventID(), 100, NON_MANAGER_ID);
         company1Order2 = createCompletedOrder(company1Event2.getEventID(), 200, NON_MANAGER_ID);
@@ -254,16 +264,8 @@ public class ProductionCompanyServiceTests {
 
         assertTrue(result.isSuccess());
 
-        List<OrderDTO> orders = result.getValue();
-
-        assertEquals(3, orders.size());
-
-        double total =
-            orders.stream()
-                .mapToDouble(OrderDTO::getTocalOrderPrice)
-                .sum();
-
-        assertEquals(450, total);
+        assertCompany1SalesHistory(result.getValue());
+        assertRepositoriesUnchanged();
     }
 
     @Test
@@ -277,16 +279,8 @@ public class ProductionCompanyServiceTests {
 
         assertTrue(result.isSuccess());
 
-        List<OrderDTO> orders = result.getValue();
-
-        assertEquals(3, orders.size());
-
-        double total =
-            orders.stream()
-                .mapToDouble(OrderDTO::getTocalOrderPrice)
-                .sum();
-
-        assertEquals(450, total);
+        assertCompany1SalesHistory(result.getValue());
+        assertRepositoriesUnchanged();
     }
 
     @Test
@@ -300,16 +294,35 @@ public class ProductionCompanyServiceTests {
 
         assertTrue(result.isSuccess());
 
-        List<OrderDTO> orders = result.getValue();
+        assertCompany1SalesHistory(result.getValue());
+        assertRepositoriesUnchanged();
+    }
 
-        assertEquals(3, orders.size());
+    @Test
+    void viewSalesHistory_NoCompletedOrders_ReturnsEmptyList() {
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_FOUNDER_TOKEN,
+                COMPANY_WITH_NO_ORDERS_ID
+            );
 
-        double total =
-            orders.stream()
-                .mapToDouble(OrderDTO::getTocalOrderPrice)
-                .sum();
+        assertTrue(result.isSuccess());
+        assertTrue(result.getValue().isEmpty());
+        assertRepositoriesUnchanged();
+    }
 
-        assertEquals(450, total);
+    @Test
+    void viewSalesHistory_CompanyWithoutEvents_ReturnsEmptyList() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_FOUNDER_TOKEN,
+                COMPANY_WITH_NO_EVENTS_ID
+            );
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.getValue().isEmpty());
+        assertRepositoriesUnchanged();
     }
 
     @Test
@@ -322,18 +335,8 @@ public class ProductionCompanyServiceTests {
             );
 
         assertFalse(result.isSuccess());
-    }
-
-    @Test
-    void viewSalesHistory_ManagerWithoutPermission_ReturnsFailure() {
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(
-                VALID_NO_USEFUL_PERMS_TOKEN,
-                COMPANY1_ID
-            );
-
-        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("dont have correct permissions"));
+        assertRepositoriesUnchanged();
     }
 
     @Test
@@ -346,6 +349,8 @@ public class ProductionCompanyServiceTests {
             );
 
         assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("dont have correct permissions"));
+        assertRepositoriesUnchanged();
     }
 
     @Test
@@ -363,6 +368,7 @@ public class ProductionCompanyServiceTests {
             "Invalid Token",
             result.getError()
         );
+        assertRepositoriesUnchanged();
     }
 
     @Test
@@ -375,11 +381,16 @@ public class ProductionCompanyServiceTests {
             );
 
         assertFalse(result.isSuccess());
+
+        assertEquals(
+            "User with ID " + BAD_USER_ID + " not found.",
+            result.getError()
+        );
+        assertRepositoriesUnchanged();
     }
 
     @Test
     void viewSalesHistory_BadCompanyID_ReturnsFailure() {
-
         Result<List<OrderDTO>> result =
             service.viewSalesHistory(
                 VALID_FOUNDER_TOKEN,
@@ -387,33 +398,53 @@ public class ProductionCompanyServiceTests {
             );
 
         assertFalse(result.isSuccess());
+        assertEquals(
+            "Production company with ID " + BAD_COMPANY_ID + " is not found.",
+            result.getError()
+        );
+        assertRepositoriesUnchanged();
     }
 
-    @Test
-    void viewSalesHistory_DoesNotReturnForeignCompanyOrders() {
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(
-                VALID_HISTORY_MANAGER_TOKEN,
-                COMPANY1_ID
-            );
-
-        assertTrue(result.isSuccess());
-
-        List<OrderDTO> orders = result.getValue();
-
+    private void assertCompany1SalesHistory(List<OrderDTO> orders) {
         assertEquals(3, orders.size());
 
-        boolean containsForeignOrder =
+        double total =
+            orders.stream()
+                .mapToDouble(OrderDTO::getTocalOrderPrice)
+                .sum();
+
+        assertEquals(450, total);
+
+        assertFalse(
             orders.stream()
                 .anyMatch(order ->
                     order.getTocalOrderPrice() == 999
-                );
+                )
+        );
 
-        assertFalse(containsForeignOrder);
+        assertFalse(
+            orders.stream()
+                .anyMatch(order ->
+                    order.getTocalOrderPrice() == 50
+                )
+        );
+
+        Set<Integer> returnedEventIds =
+            orders.stream()
+                .map(OrderDTO::getEventId)
+                .collect(Collectors.toSet());
+
+        assertEquals(
+            Set.of(
+                company1Event1.getEventID(),
+                company1Event2.getEventID()
+            ),
+            returnedEventIds
+        );
     }
-
-
-
-
+    private void assertRepositoriesUnchanged() {
+        assertEquals(5, orderRepo.getAll().size());
+        assertEquals(4, eventRepo.getAll().size());
+        assertEquals(4, companyRepo.getAll().size());
+    }
 }

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -1,18 +1,16 @@
 package com.group16b.ApplicationLayer;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
@@ -26,296 +24,467 @@ import com.group16b.DomainLayer.ProductionCompany.IProductionCompanyRepository;
 import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
 import com.group16b.DomainLayer.User.User;
+import com.group16b.InfrastructureLayer.MapDBs.EventRepositoryMapImpl;
+import com.group16b.InfrastructureLayer.MapDBs.OrderRepositoryMapImpl;
+import com.group16b.InfrastructureLayer.MapDBs.ProductionCompanyRepositoryMapImpl;
+import com.group16b.InfrastructureLayer.MapDBs.UserRepositoryMapImpl;
 
 public class ProductionCompanyServiceTests {
 
-    private ProductionCompanyService productionCompanyService;
-    private IAuthenticationService mockAuthService;
-    private IRepository<Order> mockOrderRepo;
-    private IEventRepository mockEventRepo;
-    private IRepository<User> mockUserRepo;
-    private IProductionCompanyRepository mockProductionCompanyRepository;
+    private ProductionCompanyService service;
 
-    private ProductionCompany mockCompany;
+    private IAuthenticationService authService;
+
+    private IRepository<Order> orderRepo;
+    private IEventRepository eventRepo;
+    private IRepository<User> userRepo;
+    private IProductionCompanyRepository companyRepo;
+
+    private ProductionCompany company;
+    private User manager;
 
     private final String VALID_TOKEN = "valid-token";
-    private final int COMPANY_ID = 100;
     private final String USER_ID = "1";
-    private final int EVENT_ID = 50;
+    private final int COMPANY_ID = 100;
 
     @BeforeEach
     void setUp() throws Exception {
-        mockAuthService = mock(IAuthenticationService.class);
-        mockOrderRepo = mock(IRepository.class);
-        mockEventRepo = mock(IEventRepository.class);
-        mockUserRepo = mock(IRepository.class);
-        mockProductionCompanyRepository=mock(IProductionCompanyRepository.class);
 
-        mockCompany = mock(ProductionCompany.class);
+        authService = mock(IAuthenticationService.class);
+        when(authService.validateToken(VALID_TOKEN)).thenReturn(true);
+        when(authService.isUserToken(VALID_TOKEN)).thenReturn(true);
+        when(authService.extractSubjectFromToken(VALID_TOKEN)).thenReturn(USER_ID);
 
-        productionCompanyService = new ProductionCompanyService(mockAuthService,mockOrderRepo,mockEventRepo,mockUserRepo,mockProductionCompanyRepository);
+        orderRepo = new OrderRepositoryMapImpl();
+        eventRepo = new EventRepositoryMapImpl();
+        userRepo = new UserRepositoryMapImpl();
+        companyRepo = new ProductionCompanyRepositoryMapImpl();
 
+        service = new ProductionCompanyService(
+            authService,
+            orderRepo,
+            eventRepo,
+            userRepo,
+            companyRepo
+        );
 
-        when(mockAuthService.validateToken(anyString())).thenReturn(true);
-        when(mockAuthService.isUserToken(anyString())).thenReturn(true);
-        when(mockAuthService.extractSubjectFromToken(anyString())).thenReturn(String.valueOf(USER_ID));
-        
-        when(mockProductionCompanyRepository.findByID(String.valueOf(COMPANY_ID))).thenReturn(mockCompany);
-
-        doNothing().when(mockCompany).validateUserPermissions(USER_ID, ManagerPermissions.SALES_REPORT);
-        doNothing().when(mockCompany).validateUserPermissions(USER_ID, ManagerPermissions.VIEW_PURCHASE_HISTORY);
-    
-        User mockUser = mock(User.class);
-        when(mockUserRepo.findByID(USER_ID)).thenReturn(mockUser);
+        seedBaseData();
     }
 
+    private void seedBaseData() throws Exception {
+
+        manager = createUser(USER_ID);
+        userRepo.save(manager);
+
+        company = createCompany(COMPANY_ID);
+        companyRepo.save(company);
+
+        addManagerPermissions(
+            USER_ID,
+            ManagerPermissions.SALES_REPORT,
+            ManagerPermissions.VIEW_PURCHASE_HISTORY
+        );
+    }
+
+    private User createUser(String userId) {
+
+        try {
+            return new User(
+                userId, "password");
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ProductionCompany createCompany(int companyId) {
+
+        try {
+            return new ProductionCompany(
+                companyId,
+                "TestCompany"
+            );
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Event createEvent(int eventId, int companyId) {
+
+        try {
+            return new Event(
+                eventId,
+                "Test Event " + eventId,
+                "Description",
+                "Hall",
+                100,
+                null,
+                companyId
+            );
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Order createOrder(int orderId, int eventId, double price) {
+
+        try {
+            return new Order(
+                orderId,
+                USER_ID,
+                eventId,
+                List.of(),
+                price,
+                OrderType.FIELD
+            );
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void addManagerPermissions(
+        String userId,
+        ManagerPermissions... permissions
+    ) {
+
+        try {
+            company.addManager(userId);
+
+            for (ManagerPermissions permission : permissions) {
+                company.addPermissionToManager(userId, permission);
+            }
+
+            companyRepo.update(company);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createCompanyEvent(int eventId) {
+
+        try {
+            Event event = createEvent(eventId, COMPANY_ID);
+            eventRepo.add(event);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createForeignEvent(int eventId) {
+
+        try {
+            Event event = createEvent(eventId, 999);
+            eventRepo.add(event);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createOrderForEvent(
+        int orderId,
+        int eventId,
+        double price
+    ) {
+
+        try {
+            orderRepo.add(createOrder(orderId, eventId, price));
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // =====================================================
+    // viewSalesHistory
+    // =====================================================
 
     @Test
-    void testViewSalesHistory_InvalidToken_Fail() {
-        when(mockAuthService.validateToken(VALID_TOKEN)).thenReturn(false);
+    void viewSalesHistory_InvalidToken_Fails() {
 
-        Result<List<OrderDTO>> result = productionCompanyService.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
+        authService.validToken = false;
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
 
         assertFalse(result.isSuccess());
         assertEquals("Invalid Token", result.getError());
     }
 
     @Test
-    void testViewSalesHistory_PermissionDenied_Fail() {
-        doThrow(new IllegalArgumentException("Not allowed")).when(mockCompany)
-            .validateUserPermissions(USER_ID, ManagerPermissions.VIEW_PURCHASE_HISTORY);
+    void viewSalesHistory_NotUserToken_Fails() {
 
-        Result<List<OrderDTO>> result = productionCompanyService.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
+        authService.userToken = false;
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
 
         assertFalse(result.isSuccess());
-        assertTrue(result.getError().contains("Not allowed"));
+
+        assertEquals(
+            "Only users are allowed to perform operation",
+            result.getError()
+        );
     }
 
+    @Test
+    void viewSalesHistory_StaleUser_Fails() {
+
+        authService.subject = "999";
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("999"));
+    }
 
     @Test
-    void testDisplayTotalRevenue_AsOwner_Success() {
-        // company event
-        Event matchingEvent = mock(Event.class);
+    void viewSalesHistory_CompanyNotFound_Fails() {
 
-        when(matchingEvent.getEventID())
-            .thenReturn(EVENT_ID);
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(VALID_TOKEN, 99999);
 
-        when(mockEventRepo.searchEvents(
-                null, null, null, null,
-                null, null,
-                null, null,
-                null,
-                List.of(COMPANY_ID)))
-            .thenReturn(List.of(matchingEvent));
+        assertFalse(result.isSuccess());
+    }
 
-        // matching order
-        Order matchingOrder = mock(Order.class);
+    @Test
+    void viewSalesHistory_NoPermission_Fails() {
 
-        when(matchingOrder.getEventId())
-            .thenReturn(EVENT_ID);
+        try {
+            ProductionCompany noPermissionCompany = createCompany(500);
 
-        when(matchingOrder.getTotalOrderprice())
-            .thenReturn(500D);
+            companyRepo.add(noPermissionCompany);
 
-        // non-matching order
-        Order unrelatedOrder = mock(Order.class);
+            Result<List<OrderDTO>> result =
+                service.viewSalesHistory(VALID_TOKEN, 500);
 
-        when(unrelatedOrder.getEventId())
-            .thenReturn(999);
+            assertFalse(result.isSuccess());
+        }
+        catch (Exception e) {
+            fail(e);
+        }
+    }
 
-        when(unrelatedOrder.getTotalOrderprice())
-            .thenReturn(1000D);
+    @Test
+    void viewSalesHistory_NoOrders_ReturnsEmptyList() {
 
-        when(mockOrderRepo.getAll())
-            .thenReturn(List.of(
-                matchingOrder,
-                unrelatedOrder
-            ));
-
-        Result<Double> result =
-            productionCompanyService.displayTotalRevenue(
-                VALID_TOKEN,
-                COMPANY_ID
-            );
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
 
         assertTrue(result.isSuccess(), result.getError());
-
-        // only matching company order counted
-        assertEquals(500D, result.getValue());
+        assertEquals(0, result.getValue().size());
     }
 
     @Test
-    void testDisplayTotalRevenue_MultipleEvents_SumsCorrectly() {
-        // Company has events
-        Event event1 = mock(Event.class);
-        when(event1.getEventID()).thenReturn(101);
+    void viewSalesHistory_ReturnsOnlyCompanyOrders() {
 
-        Event event2 = mock(Event.class);
-        when(event2.getEventID()).thenReturn(102);
+        createCompanyEvent(10);
+        createCompanyEvent(11);
 
-        when(mockEventRepo.searchEvents(
-                null, null, null, null,
-                null, null,
-                null, null,
-                null,
-                List.of(COMPANY_ID)))
-            .thenReturn(List.of(event1, event2));
+        createForeignEvent(99);
 
-        // Orders for event1 and event2
-        Order order1 = mock(Order.class);
-        when(order1.getEventId()).thenReturn(101);
-        when(order1.getTotalOrderprice()).thenReturn(500D);
+        createOrderForEvent(1, 10, 100);
+        createOrderForEvent(2, 11, 200);
+        createOrderForEvent(3, 99, 999);
 
-        Order order2 = mock(Order.class);
-        when(order2.getEventId()).thenReturn(102);
-        when(order2.getTotalOrderprice()).thenReturn(250D);
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
 
-        when(mockOrderRepo.getAll())
-            .thenReturn(List.of(order1, order2));
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals(2, result.getValue().size());
+    }
+
+    @Test
+    void viewSalesHistory_MultipleOrdersSameEvent_ReturnsAllOrders() {
+
+        createCompanyEvent(10);
+
+        createOrderForEvent(1, 10, 100);
+        createOrderForEvent(2, 10, 200);
+        createOrderForEvent(3, 10, 300);
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
+
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals(3, result.getValue().size());
+    }
+
+    @Test
+    void viewSalesHistory_DoesNotModifyOrders() {
+
+        createCompanyEvent(10);
+
+        createOrderForEvent(1, 10, 100);
+
+        int beforeSize = orderRepo.getAll().size();
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
+
+        int afterSize = orderRepo.getAll().size();
+
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals(beforeSize, afterSize);
+    }
+
+    // =====================================================
+    // displayTotalRevenue
+    // =====================================================
+
+    @Test
+    void displayTotalRevenue_InvalidToken_Fails() {
+
+        authService.validToken = false;
 
         Result<Double> result =
-            productionCompanyService.displayTotalRevenue(
-                VALID_TOKEN,
-                COMPANY_ID
-            );
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Invalid Token", result.getError());
+    }
+
+    @Test
+    void displayTotalRevenue_NotUserToken_Fails() {
+
+        authService.userToken = false;
+
+        Result<Double> result =
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
+
+        assertFalse(result.isSuccess());
+
+        assertEquals(
+            "Only users are allowed to perform operation",
+            result.getError()
+        );
+    }
+
+    @Test
+    void displayTotalRevenue_StaleUser_Fails() {
+
+        authService.subject = "999";
+
+        Result<Double> result =
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("999"));
+    }
+
+    @Test
+    void displayTotalRevenue_NoPermission_Fails() {
+
+        try {
+            ProductionCompany noPermissionCompany = createCompany(600);
+
+            companyRepo.add(noPermissionCompany);
+
+            Result<Double> result =
+                service.displayTotalRevenue(VALID_TOKEN, 600);
+
+            assertFalse(result.isSuccess());
+        }
+        catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void displayTotalRevenue_NoOrders_ReturnsZero() {
+
+        Result<Double> result =
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
+
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals(0D, result.getValue());
+    }
+
+    @Test
+    void displayTotalRevenue_ReturnsCorrectSum() {
+
+        createCompanyEvent(10);
+        createCompanyEvent(11);
+
+        createOrderForEvent(1, 10, 500);
+        createOrderForEvent(2, 11, 250);
+
+        Result<Double> result =
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
 
         assertTrue(result.isSuccess(), result.getError());
         assertEquals(750D, result.getValue());
     }
 
     @Test
-    void testViewSalesHistory_Success() {
-        // EVENT (IMPORTANT: uses searchEvents now, NOT findByID)
-        Event mockEvent = mock(Event.class);
-        when(mockEvent.getEventID()).thenReturn(50);
+    void displayTotalRevenue_IgnoresForeignCompanyOrders() {
 
-        when(mockEventRepo.searchEvents(
-                null, null, null, null,
-                null, null,
-                null, null,
-                null,
-                List.of(COMPANY_ID)))
-            .thenReturn(List.of(mockEvent));
+        createCompanyEvent(10);
+        createForeignEvent(99);
 
-        // ORDER linked to event
-        Order mockOrder = mock(Order.class);
-        when(mockOrder.getEventId()).thenReturn(50);
+        createOrderForEvent(1, 10, 500);
+        createOrderForEvent(2, 99, 9999);
 
-        when(mockOrder.getOrderType()).thenReturn(OrderType.FIELD); // or whatever exists
-
-        when(mockOrderRepo.getAll())
-            .thenReturn(List.of(mockOrder));
-
-        Result<List<OrderDTO>> result =
-            productionCompanyService.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
+        Result<Double> result =
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
 
         assertTrue(result.isSuccess(), result.getError());
-        assertEquals(1, result.getValue().size());
+        assertEquals(500D, result.getValue());
     }
 
     @Test
-    void testViewSalesHistory_EventNotFound_SkipsOrder() {
-        Order mockOrder = mock(Order.class, org.mockito.Mockito.RETURNS_DEEP_STUBS);
-        List<Order> orderList = new CopyOnWriteArrayList<>();
-        orderList.add(mockOrder);
-        
-        when(mockOrderRepo.getAll()).thenReturn(orderList);
-        when(mockOrder.getEventId()).thenReturn(50);
-        
-        when(mockEventRepo.findByID(String.valueOf(50))).thenReturn(null); 
+    void displayTotalRevenue_MultipleOrdersSameEvent_SumsCorrectly() {
 
-        Result<List<OrderDTO>> result = productionCompanyService.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
+        createCompanyEvent(10);
 
-        assertTrue(result.isSuccess(), "Service crashed with error: " + result.getError());
-        assertEquals(0, result.getValue().size(), "Order should be skipped if event is missing");
-    }
+        createOrderForEvent(1, 10, 100);
+        createOrderForEvent(2, 10, 200);
+        createOrderForEvent(3, 10, 300);
 
-    @Test
-    void testViewSalesHistory_WrongCompany_SkipsOrder() {
-        Order mockOrder = mock(Order.class, org.mockito.Mockito.RETURNS_DEEP_STUBS);
-        Event mockEvent = mock(Event.class);
-        
-        List<Order> orderList = new CopyOnWriteArrayList<>();
-        orderList.add(mockOrder);
-    
-        when(mockOrderRepo.getAll()).thenReturn(orderList);
-        when(mockOrder.getEventId()).thenReturn(50);
-        when(mockEventRepo.findByID(String.valueOf(50))).thenReturn(mockEvent);
-        
-        when(mockEvent.getEventProductionCompanyID()).thenReturn(999); 
-
-        Result<List<OrderDTO>> result = productionCompanyService.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), "Service crashed with error: " + result.getError());
-        assertEquals(0, result.getValue().size(), "Order should be skipped if it belongs to a different company");
-    }
-
-    
-    @Test
-    void testDisplayTotalRevenue_AsManagerUnderOwner_Success() {
-        // ---------- EVENTS ----------
-        Event mockEvent = mock(Event.class);
-        when(mockEvent.getEventID()).thenReturn(100);
-
-        when(mockEventRepo.searchEvents(
-                null, null, null, null,
-                null, null,
-                null, null,
-                null,
-                List.of(COMPANY_ID)))
-            .thenReturn(List.of(mockEvent));
-
-        // ---------- ORDERS ----------
-        Order mockOrder = mock(Order.class);
-        when(mockOrder.getEventId()).thenReturn(100);
-        when(mockOrder.getTotalOrderprice()).thenReturn(300D);
-
-        // required by DTO (avoid previous crash)
-        when(mockOrder.getOrderType()).thenReturn(OrderType.FIELD);
-
-        when(mockOrderRepo.getAll())
-            .thenReturn(List.of(mockOrder));
-
-        // ---------- CALL ----------
         Result<Double> result =
-            productionCompanyService.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
 
-        // ---------- ASSERT ----------
         assertTrue(result.isSuccess(), result.getError());
-        assertEquals(300D, result.getValue());
+        assertEquals(600D, result.getValue());
     }
 
     @Test
-    void testDisplayTotalRevenue_CompanyNotFound_Fails() {
-        doThrow(new IllegalArgumentException("No company")).when(mockProductionCompanyRepository).findByID(String.valueOf(COMPANY_ID));
+    void displayTotalRevenue_DecimalRevenue_SumsCorrectly() {
 
-        Result<Double> result =productionCompanyService.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
+        createCompanyEvent(10);
 
-        assertFalse(result.isSuccess());
-    }
-
-    @Test
-    void testDisplayTotalRevenue_PermissionDenied_Fail() {
-        doThrow(new IllegalArgumentException("Not allowed"))
-            .when(mockCompany)
-            .validateUserPermissions(USER_ID, ManagerPermissions.SALES_REPORT);
+        createOrderForEvent(1, 10, 100.25);
+        createOrderForEvent(2, 10, 200.75);
 
         Result<Double> result =
-            productionCompanyService.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
 
-        assertFalse(result.isSuccess());
-        assertTrue(result.getError().contains("Not allowed"));
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals(301D, result.getValue());
     }
 
     @Test
-    void testDisplayTotalRevenue_CompanyRepoThrows_Fail() {
-        doThrow(new RuntimeException("DB error"))
-            .when(mockProductionCompanyRepository)
-            .findByID(String.valueOf(COMPANY_ID));
+    void displayTotalRevenue_DoesNotModifyOrders() {
+
+        createCompanyEvent(10);
+
+        createOrderForEvent(1, 10, 100);
+
+        int beforeSize = orderRepo.getAll().size();
 
         Result<Double> result =
-            productionCompanyService.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
+            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
 
-        assertFalse(result.isSuccess());
+        int afterSize = orderRepo.getAll().size();
+
+        assertTrue(result.isSuccess(), result.getError());
+        assertEquals(beforeSize, afterSize);
     }
+
 }

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -41,19 +41,64 @@ public class ProductionCompanyServiceTests {
     private IProductionCompanyRepository companyRepo;
 
     private ProductionCompany company;
-    private User manager;
+    private User managerForHistory;
+    private User managerForRevenue;
+    private User managerWithNoUsefullPerms;
+    private User founder;
+    private User non_manager;
+    private User owner;
 
-    private final String VALID_TOKEN = "valid-token";
-    private final String USER_ID = "1";
+    private final String VALID_FOUNDER_TOKEN = "valid-foudner-token";
+    private final String VALID_HISTORY_MANAGER_TOKEN = "valid-history-manager-token";
+    private final String VALID_REVENUE_MANAGER_TOKEN = "valid-revenue-manager-token";
+    private final String VALID_NO_USEFUL_PERMS_TOKEN = "valid-no-useful-perms-token";
+    private final String VALID_NON_MANAGER_TOKEN = "valid-non-manager-token";
+    private final String VALID_OWNER_TOKEN = "valid-owner-token";
+    private final String INVALID_TOKEN = "invalid-token";
+    private final String MANAGER_FOR_HISTORY_ID = "1";
+    private final String MANAGER_FOR_REVENUE_ID = "2";
+    private final String MANAGER_WITH_NO_USEFUL_PERMS_ID = "3";
+    private final String NON_MANAGER_ID = "4";
+    private final String OWNER_ID = "5";
     private final int COMPANY_ID = 100;
+    private final int BAD_COMPANY_ID = 999;
+    private final String BAD_USER_ID = "999";
+    private final String COMPANY_ID_STRING = String.valueOf(COMPANY_ID);
+    private final String FOUNDER_EMAIL="founder@example.com";
+    private final String TEST_COMPANY_NAME="TestCompany";
 
+
+    
+    
+    
     @BeforeEach
     void setUp() throws Exception {
-
         authService = mock(IAuthenticationService.class);
-        when(authService.validateToken(VALID_TOKEN)).thenReturn(true);
-        when(authService.isUserToken(VALID_TOKEN)).thenReturn(true);
-        when(authService.extractSubjectFromToken(VALID_TOKEN)).thenReturn(USER_ID);
+        when(authService.validateToken(VALID_FOUNDER_TOKEN)).thenReturn(true);
+        when(authService.isUserToken(VALID_FOUNDER_TOKEN)).thenReturn(true);
+        when(authService.extractSubjectFromToken(VALID_FOUNDER_TOKEN)).thenReturn(FOUNDER_EMAIL);
+
+        when(authService.validateToken(VALID_HISTORY_MANAGER_TOKEN)).thenReturn(true);
+        when(authService.isUserToken(VALID_HISTORY_MANAGER_TOKEN)).thenReturn(true);
+        when(authService.extractSubjectFromToken(VALID_HISTORY_MANAGER_TOKEN)).thenReturn(MANAGER_FOR_HISTORY_ID);
+
+        when(authService.validateToken(VALID_NO_USEFUL_PERMS_TOKEN)).thenReturn(true);
+        when(authService.isUserToken(VALID_NO_USEFUL_PERMS_TOKEN)).thenReturn(true);
+        when(authService.extractSubjectFromToken(VALID_NO_USEFUL_PERMS_TOKEN)).thenReturn(MANAGER_WITH_NO_USEFUL_PERMS_ID);
+
+        when(authService.validateToken(VALID_REVENUE_MANAGER_TOKEN)).thenReturn(true);
+        when(authService.isUserToken(VALID_REVENUE_MANAGER_TOKEN)).thenReturn(true);
+        when(authService.extractSubjectFromToken(VALID_REVENUE_MANAGER_TOKEN)).thenReturn(MANAGER_FOR_REVENUE_ID);
+
+        when(authService.validateToken(VALID_NON_MANAGER_TOKEN)).thenReturn(true);
+        when(authService.isUserToken(VALID_NON_MANAGER_TOKEN)).thenReturn(true);
+        when(authService.extractSubjectFromToken(VALID_NON_MANAGER_TOKEN)).thenReturn(NON_MANAGER_ID);
+
+        when(authService.validateToken(VALID_OWNER_TOKEN)).thenReturn(true);
+        when(authService.isUserToken(VALID_OWNER_TOKEN)).thenReturn(true);
+        when(authService.extractSubjectFromToken(VALID_OWNER_TOKEN)).thenReturn(OWNER_ID);
+
+        when(authService.validateToken(INVALID_TOKEN)).thenReturn(false);
 
         orderRepo = new OrderRepositoryMapImpl();
         eventRepo = new EventRepositoryMapImpl();
@@ -66,7 +111,7 @@ public class ProductionCompanyServiceTests {
             eventRepo,
             userRepo,
             companyRepo
-        );
+);
 
         seedBaseData();
     }
@@ -76,14 +121,16 @@ public class ProductionCompanyServiceTests {
         manager = createUser(USER_ID);
         userRepo.save(manager);
 
-        company = createCompany(COMPANY_ID);
+        founder=createUser(FOUNDER_EMAIL);
+        userRepo.save(founder);
+
+        company = createCompany(COMPANY_ID, TEST_COMPANY_NAME, FOUNDER_EMAIL);
         companyRepo.save(company);
 
         addManagerPermissions(
             USER_ID,
             ManagerPermissions.SALES_REPORT,
-            ManagerPermissions.VIEW_PURCHASE_HISTORY
-        );
+            ManagerPermissions.VIEW_PURCHASE_HISTORY);
     }
 
     private User createUser(String userId) {
@@ -97,17 +144,8 @@ public class ProductionCompanyServiceTests {
         }
     }
 
-    private ProductionCompany createCompany(int companyId) {
-
-        try {
-            return new ProductionCompany(
-                companyId,
-                "TestCompany"
-            );
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private ProductionCompany createCompany(int companyId,String name,String founderEmail) {
+        return new ProductionCompany(companyId,name,1.1,founderEmail);
     }
 
     private Event createEvent(int eventId, int companyId) {
@@ -145,10 +183,7 @@ public class ProductionCompanyServiceTests {
         }
     }
 
-    private void addManagerPermissions(
-        String userId,
-        ManagerPermissions... permissions
-    ) {
+    private void addManagerPermissions(String userId,ManagerPermissions... permissions) {
 
         try {
             company.addManager(userId);
@@ -200,291 +235,5 @@ public class ProductionCompanyServiceTests {
         }
     }
 
-    // =====================================================
-    // viewSalesHistory
-    // =====================================================
-
-    @Test
-    void viewSalesHistory_InvalidToken_Fails() {
-
-        authService.validToken = false;
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
-
-        assertFalse(result.isSuccess());
-        assertEquals("Invalid Token", result.getError());
-    }
-
-    @Test
-    void viewSalesHistory_NotUserToken_Fails() {
-
-        authService.userToken = false;
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
-
-        assertFalse(result.isSuccess());
-
-        assertEquals(
-            "Only users are allowed to perform operation",
-            result.getError()
-        );
-    }
-
-    @Test
-    void viewSalesHistory_StaleUser_Fails() {
-
-        authService.subject = "999";
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
-
-        assertFalse(result.isSuccess());
-        assertTrue(result.getError().contains("999"));
-    }
-
-    @Test
-    void viewSalesHistory_CompanyNotFound_Fails() {
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(VALID_TOKEN, 99999);
-
-        assertFalse(result.isSuccess());
-    }
-
-    @Test
-    void viewSalesHistory_NoPermission_Fails() {
-
-        try {
-            ProductionCompany noPermissionCompany = createCompany(500);
-
-            companyRepo.add(noPermissionCompany);
-
-            Result<List<OrderDTO>> result =
-                service.viewSalesHistory(VALID_TOKEN, 500);
-
-            assertFalse(result.isSuccess());
-        }
-        catch (Exception e) {
-            fail(e);
-        }
-    }
-
-    @Test
-    void viewSalesHistory_NoOrders_ReturnsEmptyList() {
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(0, result.getValue().size());
-    }
-
-    @Test
-    void viewSalesHistory_ReturnsOnlyCompanyOrders() {
-
-        createCompanyEvent(10);
-        createCompanyEvent(11);
-
-        createForeignEvent(99);
-
-        createOrderForEvent(1, 10, 100);
-        createOrderForEvent(2, 11, 200);
-        createOrderForEvent(3, 99, 999);
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(2, result.getValue().size());
-    }
-
-    @Test
-    void viewSalesHistory_MultipleOrdersSameEvent_ReturnsAllOrders() {
-
-        createCompanyEvent(10);
-
-        createOrderForEvent(1, 10, 100);
-        createOrderForEvent(2, 10, 200);
-        createOrderForEvent(3, 10, 300);
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(3, result.getValue().size());
-    }
-
-    @Test
-    void viewSalesHistory_DoesNotModifyOrders() {
-
-        createCompanyEvent(10);
-
-        createOrderForEvent(1, 10, 100);
-
-        int beforeSize = orderRepo.getAll().size();
-
-        Result<List<OrderDTO>> result =
-            service.viewSalesHistory(VALID_TOKEN, COMPANY_ID);
-
-        int afterSize = orderRepo.getAll().size();
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(beforeSize, afterSize);
-    }
-
-    // =====================================================
-    // displayTotalRevenue
-    // =====================================================
-
-    @Test
-    void displayTotalRevenue_InvalidToken_Fails() {
-
-        authService.validToken = false;
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        assertFalse(result.isSuccess());
-        assertEquals("Invalid Token", result.getError());
-    }
-
-    @Test
-    void displayTotalRevenue_NotUserToken_Fails() {
-
-        authService.userToken = false;
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        assertFalse(result.isSuccess());
-
-        assertEquals(
-            "Only users are allowed to perform operation",
-            result.getError()
-        );
-    }
-
-    @Test
-    void displayTotalRevenue_StaleUser_Fails() {
-
-        authService.subject = "999";
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        assertFalse(result.isSuccess());
-        assertTrue(result.getError().contains("999"));
-    }
-
-    @Test
-    void displayTotalRevenue_NoPermission_Fails() {
-
-        try {
-            ProductionCompany noPermissionCompany = createCompany(600);
-
-            companyRepo.add(noPermissionCompany);
-
-            Result<Double> result =
-                service.displayTotalRevenue(VALID_TOKEN, 600);
-
-            assertFalse(result.isSuccess());
-        }
-        catch (Exception e) {
-            fail(e);
-        }
-    }
-
-    @Test
-    void displayTotalRevenue_NoOrders_ReturnsZero() {
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(0D, result.getValue());
-    }
-
-    @Test
-    void displayTotalRevenue_ReturnsCorrectSum() {
-
-        createCompanyEvent(10);
-        createCompanyEvent(11);
-
-        createOrderForEvent(1, 10, 500);
-        createOrderForEvent(2, 11, 250);
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(750D, result.getValue());
-    }
-
-    @Test
-    void displayTotalRevenue_IgnoresForeignCompanyOrders() {
-
-        createCompanyEvent(10);
-        createForeignEvent(99);
-
-        createOrderForEvent(1, 10, 500);
-        createOrderForEvent(2, 99, 9999);
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(500D, result.getValue());
-    }
-
-    @Test
-    void displayTotalRevenue_MultipleOrdersSameEvent_SumsCorrectly() {
-
-        createCompanyEvent(10);
-
-        createOrderForEvent(1, 10, 100);
-        createOrderForEvent(2, 10, 200);
-        createOrderForEvent(3, 10, 300);
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(600D, result.getValue());
-    }
-
-    @Test
-    void displayTotalRevenue_DecimalRevenue_SumsCorrectly() {
-
-        createCompanyEvent(10);
-
-        createOrderForEvent(1, 10, 100.25);
-        createOrderForEvent(2, 10, 200.75);
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(301D, result.getValue());
-    }
-
-    @Test
-    void displayTotalRevenue_DoesNotModifyOrders() {
-
-        createCompanyEvent(10);
-
-        createOrderForEvent(1, 10, 100);
-
-        int beforeSize = orderRepo.getAll().size();
-
-        Result<Double> result =
-            service.displayTotalRevenue(VALID_TOKEN, COMPANY_ID);
-
-        int afterSize = orderRepo.getAll().size();
-
-        assertTrue(result.isSuccess(), result.getError());
-        assertEquals(beforeSize, afterSize);
-    }
 
 }

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -82,6 +82,7 @@ public class ProductionCompanyServiceTests {
     private Order company1Order2;
     private Order company1Order3;
     private Order company2Order1;
+    private Order company1ActiveOrder1;
 
 
     
@@ -170,15 +171,18 @@ public class ProductionCompanyServiceTests {
         eventRepo.save(company1Event2);
         eventRepo.save(company2Event1);
 
-        company1Order1 = createOrder(company1Event1.getEventID(), 100, NON_MANAGER_ID);
-        company1Order2 = createOrder(company1Event2.getEventID(), 200, NON_MANAGER_ID);
-        company1Order3 = createOrder(company1Event2.getEventID(), 150, NON_MANAGER_ID);
-        company2Order1 = createOrder(company2Event1.getEventID(), 999, NON_MANAGER_ID);
+        company1Order1 = createCompletedOrder(company1Event1.getEventID(), 100, NON_MANAGER_ID);
+        company1Order2 = createCompletedOrder(company1Event2.getEventID(), 200, NON_MANAGER_ID);
+        company1Order3 = createCompletedOrder(company1Event2.getEventID(), 150, NON_MANAGER_ID);
+        company2Order1 = createCompletedOrder(company2Event1.getEventID(), 999, NON_MANAGER_ID);
+
+        company1ActiveOrder1 = createOrder(company1Event1.getEventID(), 50, NON_MANAGER_ID);
 
         orderRepo.save(company1Order1);
         orderRepo.save(company1Order2);
         orderRepo.save(company1Order3);
         orderRepo.save(company2Order1);
+        orderRepo.save(company1ActiveOrder1);
     }
 
     private User createUser(String userId) {
@@ -220,6 +224,10 @@ public class ProductionCompanyServiceTests {
             eventId,
             subjectID
         );
+        return order;
+    }
+    private Order createCompletedOrder(int eventId, double price, String subjectID) {
+        Order order = createOrder(eventId, price, subjectID);
         order.CompleteOrder();
         return order;
     }

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.group16b.ApplicationLayer.DTOs.OrderDTO;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.ApplicationLayer.Objects.Result;
 import com.group16b.ApplicationLayer.Records.EventRecord;
@@ -212,13 +213,15 @@ public class ProductionCompanyServiceTests {
     }
 
     private Order createOrder(int eventId, double price, String subjectID) {
-        return new Order(
+        Order order=new Order(
             "seg",
             List.of("A1", "A2"),
             price,
             eventId,
             subjectID
         );
+        order.CompleteOrder();
+        return order;
     }
 
     private void assignManagerToCompany(ProductionCompany company, String managerId, String founderID,Set<ManagerPermissions> perms) {
@@ -232,6 +235,175 @@ public class ProductionCompanyServiceTests {
     }
 
 
+    @Test
+    void viewSalesHistory_Founder_ReturnsAllCompanyOrders() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_FOUNDER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertTrue(result.isSuccess());
+
+        List<OrderDTO> orders = result.getValue();
+
+        assertEquals(3, orders.size());
+
+        double total =
+            orders.stream()
+                .mapToDouble(OrderDTO::getTocalOrderPrice)
+                .sum();
+
+        assertEquals(450, total);
+    }
+
+    @Test
+    void viewSalesHistory_HistoryManager_ReturnsAllCompanyOrders() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_HISTORY_MANAGER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertTrue(result.isSuccess());
+
+        List<OrderDTO> orders = result.getValue();
+
+        assertEquals(3, orders.size());
+
+        double total =
+            orders.stream()
+                .mapToDouble(OrderDTO::getTocalOrderPrice)
+                .sum();
+
+        assertEquals(450, total);
+    }
+
+    @Test
+    void viewSalesHistory_Owner_ReturnsAllCompanyOrders() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_OWNER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertTrue(result.isSuccess());
+
+        List<OrderDTO> orders = result.getValue();
+
+        assertEquals(3, orders.size());
+
+        double total =
+            orders.stream()
+                .mapToDouble(OrderDTO::getTocalOrderPrice)
+                .sum();
+
+        assertEquals(450, total);
+    }
+
+    @Test
+    void viewSalesHistory_RevenueManagerWithoutHistoryPermission_ReturnsFailure() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_REVENUE_MANAGER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    void viewSalesHistory_ManagerWithoutPermission_ReturnsFailure() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_NO_USEFUL_PERMS_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    void viewSalesHistory_NonManager_ReturnsFailure() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_NON_MANAGER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    void viewSalesHistory_InvalidToken_ReturnsFailure() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                INVALID_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+
+        assertEquals(
+            "Invalid Token",
+            result.getError()
+        );
+    }
+
+    @Test
+    void viewSalesHistory_StaleUserToken_ReturnsFailure() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                STALE_USER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    void viewSalesHistory_BadCompanyID_ReturnsFailure() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_FOUNDER_TOKEN,
+                BAD_COMPANY_ID
+            );
+
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    void viewSalesHistory_DoesNotReturnForeignCompanyOrders() {
+
+        Result<List<OrderDTO>> result =
+            service.viewSalesHistory(
+                VALID_HISTORY_MANAGER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertTrue(result.isSuccess());
+
+        List<OrderDTO> orders = result.getValue();
+
+        assertEquals(3, orders.size());
+
+        boolean containsForeignOrder =
+            orders.stream()
+                .anyMatch(order ->
+                    order.getTocalOrderPrice() == 999
+                );
+
+        assertFalse(containsForeignOrder);
+    }
 
 
 

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -171,10 +171,10 @@ public class ProductionCompanyServiceTests {
         companyRepo.save(companyWithNoEvents);
         companyRepo.save(companyWithNoOrders);
 
-        company1Event1 = createEvent(1, COMPANY1_ID);
-        company1Event2 = createEvent(2, COMPANY1_ID);
-        company2Event1 = createEvent(3, COMPANY2_ID);
-        companyWithNoOrdersEvent1 = createEvent(4, COMPANY_WITH_NO_ORDERS_ID);
+        company1Event1 = createEvent(1, COMPANY1_ID, FOUNDER_EMAIL);
+        company1Event2 = createEvent(2, COMPANY1_ID, OWNER_ID);
+        company2Event1 = createEvent(3, COMPANY2_ID, OWNER_ID);
+        companyWithNoOrdersEvent1 = createEvent(4, COMPANY_WITH_NO_ORDERS_ID, FOUNDER_EMAIL);
 
         eventRepo.save(company1Event1);
         eventRepo.save(company1Event2);
@@ -210,7 +210,7 @@ public class ProductionCompanyServiceTests {
         return new ProductionCompany(companyId,name,1.1,founderEmail);
     }
 
-    private Event createEvent(int eventId, int companyId) {
+    private Event createEvent(int eventId, int companyId,String ownerId) {
         return new Event(
             new EventRecord(
                 "venue1",
@@ -222,7 +222,7 @@ public class ProductionCompanyServiceTests {
                 companyId,
                 100,
                 4.5
-            ),"owner"
+            ),ownerId
             );
     }
 
@@ -403,10 +403,7 @@ public class ProductionCompanyServiceTests {
     private void assertCompany1SalesHistory(List<OrderDTO> orders) {
         assertEquals(3, orders.size());
 
-        double total =
-            orders.stream()
-                .mapToDouble(OrderDTO::getTocalOrderPrice)
-                .sum();
+        double total =orders.stream().mapToDouble(OrderDTO::getTocalOrderPrice).sum();
 
         assertEquals(450, total);
 
@@ -442,4 +439,151 @@ public class ProductionCompanyServiceTests {
         assertEquals(4, eventRepo.getAll().size());
         assertEquals(4, companyRepo.getAll().size());
     }
+
+    // =======================================================
+    // displayTotalRevenue TESTS
+    // =======================================================
+
+    @Test
+    void displayTotalRevenue_Founder_ReturnsAllCompanyRevenue() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                VALID_FOUNDER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertTrue(result.isSuccess());
+
+        // company1:
+        // order1 = 100 (event1)
+        // order2 = 200 (event2)
+        // order3 = 150 (event2)
+        // active order excluded
+        // total = 450
+        assertEquals(450.0, result.getValue());
+
+        assertRepositoriesUnchanged();
+    }
+    @Test
+    void displayTotalRevenue_Owner_ReturnsAllCompanyRevenue() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                VALID_OWNER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertTrue(result.isSuccess());
+
+        // company1:
+        // order2 = 200 (event2)
+        // order3 = 150 (event2)
+        // active order excluded
+        // total = 350
+        assertEquals(350.0, result.getValue());
+
+        assertRepositoriesUnchanged();
+    }
+
+    @Test
+    void displayTotalRevenue_ManagerWithoutSalesPermission_ReturnsFailure() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                VALID_HISTORY_MANAGER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("permissions"));
+
+        assertRepositoriesUnchanged();
+    }
+
+    @Test
+    void displayTotalRevenue_NonManager_ReturnsFailure() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                VALID_NON_MANAGER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("permissions"));
+
+        assertRepositoriesUnchanged();
+    }
+
+    @Test
+    void displayTotalRevenue_InvalidToken_ReturnsFailure() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                INVALID_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+        assertEquals("Invalid Token", result.getError());
+
+        assertRepositoriesUnchanged();
+    }
+
+    @Test
+    void displayTotalRevenue_StaleUser_ReturnsFailure() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                STALE_USER_TOKEN,
+                COMPANY1_ID
+            );
+
+        assertFalse(result.isSuccess());
+        assertEquals(
+            "User with ID " + BAD_USER_ID + " not found.",
+            result.getError()
+        );
+
+        assertRepositoriesUnchanged();
+    }
+
+    @Test
+    void displayTotalRevenue_InvalidCompany_ReturnsFailure() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                VALID_FOUNDER_TOKEN,
+                BAD_COMPANY_ID
+            );
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("not found"));
+
+        assertRepositoriesUnchanged();
+    }
+
+    @Test
+    void displayTotalRevenue_CompanyWithNoEvents_ReturnsZero() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                VALID_FOUNDER_TOKEN,
+                COMPANY_WITH_NO_EVENTS_ID
+            );
+
+        assertTrue(result.isSuccess());
+        assertEquals(0.0, result.getValue());
+
+        assertRepositoriesUnchanged();
+    }
+
+    @Test
+    void displayTotalRevenue_CompanyWithNoCompletedOrders_ReturnsZero() {
+        Result<Double> result =
+            service.displayTotalRevenue(
+                VALID_FOUNDER_TOKEN,
+                COMPANY_WITH_NO_ORDERS_ID
+            );
+
+        assertTrue(result.isSuccess());
+        assertEquals(0.0, result.getValue());
+
+        assertRepositoriesUnchanged();
+    }
+
+
 }

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -7,19 +7,20 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.group16b.ApplicationLayer.DTOs.OrderDTO;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.ApplicationLayer.Objects.Result;
+import com.group16b.ApplicationLayer.Records.EventRecord;
 import com.group16b.DomainLayer.Event.Event;
 import com.group16b.DomainLayer.Event.IEventRepository;
 import com.group16b.DomainLayer.Interfaces.IRepository;
 import com.group16b.DomainLayer.Order.Order;
-import com.group16b.DomainLayer.Order.OrderType;
 import com.group16b.DomainLayer.ProductionCompany.IProductionCompanyRepository;
 import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
@@ -40,7 +41,8 @@ public class ProductionCompanyServiceTests {
     private IRepository<User> userRepo;
     private IProductionCompanyRepository companyRepo;
 
-    private ProductionCompany company;
+    private ProductionCompany company1;
+    private ProductionCompany company2;
     private User managerForHistory;
     private User managerForRevenue;
     private User managerWithNoUsefullPerms;
@@ -55,17 +57,30 @@ public class ProductionCompanyServiceTests {
     private final String VALID_NON_MANAGER_TOKEN = "valid-non-manager-token";
     private final String VALID_OWNER_TOKEN = "valid-owner-token";
     private final String INVALID_TOKEN = "invalid-token";
+    private final String STALE_USER_TOKEN = "stale-user-token";
     private final String MANAGER_FOR_HISTORY_ID = "1";
     private final String MANAGER_FOR_REVENUE_ID = "2";
     private final String MANAGER_WITH_NO_USEFUL_PERMS_ID = "3";
     private final String NON_MANAGER_ID = "4";
     private final String OWNER_ID = "5";
-    private final int COMPANY_ID = 100;
+    private final int COMPANY1_ID = 100;
+    private final int COMPANY2_ID = 101;
     private final int BAD_COMPANY_ID = 999;
     private final String BAD_USER_ID = "999";
-    private final String COMPANY_ID_STRING = String.valueOf(COMPANY_ID);
+    private final String COMPANY1_ID_STRING = String.valueOf(COMPANY1_ID);
+    private final String COMPANY2_ID_STRING = String.valueOf(COMPANY2_ID);
     private final String FOUNDER_EMAIL="founder@example.com";
-    private final String TEST_COMPANY_NAME="TestCompany";
+    private final String COMPANY1_NAME="Company1";
+    private final String COMPANY2_NAME="Company2";
+
+    private Event company1Event1;
+    private Event company1Event2;
+    private Event company2Event1;
+
+    private Order company1Order1;
+    private Order company1Order2;
+    private Order company1Order3;
+    private Order company2Order1;
 
 
     
@@ -98,6 +113,10 @@ public class ProductionCompanyServiceTests {
         when(authService.isUserToken(VALID_OWNER_TOKEN)).thenReturn(true);
         when(authService.extractSubjectFromToken(VALID_OWNER_TOKEN)).thenReturn(OWNER_ID);
 
+        when(authService.validateToken(STALE_USER_TOKEN)).thenReturn(true);
+        when(authService.isUserToken(STALE_USER_TOKEN)).thenReturn(true);
+        when(authService.extractSubjectFromToken(STALE_USER_TOKEN)).thenReturn(BAD_USER_ID);
+
         when(authService.validateToken(INVALID_TOKEN)).thenReturn(false);
 
         orderRepo = new OrderRepositoryMapImpl();
@@ -111,26 +130,54 @@ public class ProductionCompanyServiceTests {
             eventRepo,
             userRepo,
             companyRepo
-);
+        );
 
         seedBaseData();
     }
 
     private void seedBaseData() throws Exception {
+        founder = createUser(FOUNDER_EMAIL);
+        managerForHistory = createUser(MANAGER_FOR_HISTORY_ID);
+        managerForRevenue = createUser(MANAGER_FOR_REVENUE_ID);
+        managerWithNoUsefullPerms = createUser(MANAGER_WITH_NO_USEFUL_PERMS_ID);
+        non_manager = createUser(NON_MANAGER_ID);
+        owner = createUser(OWNER_ID);
 
-        manager = createUser(USER_ID);
-        userRepo.save(manager);
-
-        founder=createUser(FOUNDER_EMAIL);
         userRepo.save(founder);
+        userRepo.save(managerForHistory);
+        userRepo.save(managerForRevenue);
+        userRepo.save(managerWithNoUsefullPerms);
+        userRepo.save(non_manager);
+        userRepo.save(owner);
 
-        company = createCompany(COMPANY_ID, TEST_COMPANY_NAME, FOUNDER_EMAIL);
-        companyRepo.save(company);
+        company1 = createCompany(COMPANY1_ID, COMPANY1_NAME, FOUNDER_EMAIL);
+        company2 = createCompany(COMPANY2_ID, COMPANY2_NAME, FOUNDER_EMAIL);
 
-        addManagerPermissions(
-            USER_ID,
-            ManagerPermissions.SALES_REPORT,
-            ManagerPermissions.VIEW_PURCHASE_HISTORY);
+        assignManagerToCompany(company1, MANAGER_FOR_HISTORY_ID, FOUNDER_EMAIL, Set.of(ManagerPermissions.VIEW_PURCHASE_HISTORY));
+        assignOwnerToCompany(company1, OWNER_ID, FOUNDER_EMAIL);
+        assignManagerToCompany(company1, MANAGER_FOR_REVENUE_ID, OWNER_ID, Set.of(ManagerPermissions.SALES_REPORT));
+        assignManagerToCompany(company1, MANAGER_WITH_NO_USEFUL_PERMS_ID, OWNER_ID, Set.of(ManagerPermissions.CUSTOMER_SUPPORT));
+
+        companyRepo.save(company1);
+        companyRepo.save(company2);
+
+        company1Event1 = createEvent(1, COMPANY1_ID);
+        company1Event2 = createEvent(2, COMPANY1_ID);
+        company2Event1 = createEvent(3, COMPANY2_ID);
+
+        eventRepo.save(company1Event1);
+        eventRepo.save(company1Event2);
+        eventRepo.save(company2Event1);
+
+        company1Order1 = createOrder(company1Event1.getEventID(), 100, NON_MANAGER_ID);
+        company1Order2 = createOrder(company1Event2.getEventID(), 200, NON_MANAGER_ID);
+        company1Order3 = createOrder(company1Event2.getEventID(), 150, NON_MANAGER_ID);
+        company2Order1 = createOrder(company2Event1.getEventID(), 999, NON_MANAGER_ID);
+
+        orderRepo.save(company1Order1);
+        orderRepo.save(company1Order2);
+        orderRepo.save(company1Order3);
+        orderRepo.save(company2Order1);
     }
 
     private User createUser(String userId) {
@@ -149,91 +196,44 @@ public class ProductionCompanyServiceTests {
     }
 
     private Event createEvent(int eventId, int companyId) {
-
-        try {
-            return new Event(
-                eventId,
-                "Test Event " + eventId,
-                "Description",
-                "Hall",
+        return new Event(
+            new EventRecord(
+                "venue1",
+                "Event " + eventId,
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                "Artist",
+                "Category",
+                companyId,
                 100,
-                null,
-                companyId
+                4.5
+            ),"owner"
             );
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
-    private Order createOrder(int orderId, int eventId, double price) {
-
-        try {
-            return new Order(
-                orderId,
-                USER_ID,
-                eventId,
-                List.of(),
-                price,
-                OrderType.FIELD
-            );
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private Order createOrder(int eventId, double price, String subjectID) {
+        return new Order(
+            "seg",
+            List.of("A1", "A2"),
+            price,
+            eventId,
+            subjectID
+        );
     }
 
-    private void addManagerPermissions(String userId,ManagerPermissions... permissions) {
-
-        try {
-            company.addManager(userId);
-
-            for (ManagerPermissions permission : permissions) {
-                company.addPermissionToManager(userId, permission);
-            }
-
-            companyRepo.update(company);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private void assignManagerToCompany(ProductionCompany company, String managerId, String founderID,Set<ManagerPermissions> perms) {
+        company.AssignManager(founderID, managerId, perms);
+        company.acceptInvite(managerId, founderID);
     }
 
-    private void createCompanyEvent(int eventId) {
-
-        try {
-            Event event = createEvent(eventId, COMPANY_ID);
-            eventRepo.add(event);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private void assignOwnerToCompany(ProductionCompany company, String newOwnerId, String founderID) {
+        company.AssignOwner(founderID, newOwnerId);
+        company.acceptInvite(newOwnerId, founderID);
     }
 
-    private void createForeignEvent(int eventId) {
 
-        try {
-            Event event = createEvent(eventId, 999);
-            eventRepo.add(event);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 
-    private void createOrderForEvent(
-        int orderId,
-        int eventId,
-        double price
-    ) {
 
-        try {
-            orderRepo.add(createOrder(orderId, eventId, price));
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 
 
 }

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -313,7 +313,6 @@ public class ProductionCompanyServiceTests {
 
     @Test
     void viewSalesHistory_CompanyWithoutEvents_ReturnsEmptyList() {
-
         Result<List<OrderDTO>> result =
             service.viewSalesHistory(
                 VALID_FOUNDER_TOKEN,
@@ -327,7 +326,6 @@ public class ProductionCompanyServiceTests {
 
     @Test
     void viewSalesHistory_RevenueManagerWithoutHistoryPermission_ReturnsFailure() {
-
         Result<List<OrderDTO>> result =
             service.viewSalesHistory(
                 VALID_REVENUE_MANAGER_TOKEN,
@@ -341,7 +339,6 @@ public class ProductionCompanyServiceTests {
 
     @Test
     void viewSalesHistory_NonManager_ReturnsFailure() {
-
         Result<List<OrderDTO>> result =
             service.viewSalesHistory(
                 VALID_NON_MANAGER_TOKEN,
@@ -355,7 +352,6 @@ public class ProductionCompanyServiceTests {
 
     @Test
     void viewSalesHistory_InvalidToken_ReturnsFailure() {
-
         Result<List<OrderDTO>> result =
             service.viewSalesHistory(
                 INVALID_TOKEN,
@@ -373,7 +369,6 @@ public class ProductionCompanyServiceTests {
 
     @Test
     void viewSalesHistory_StaleUserToken_ReturnsFailure() {
-
         Result<List<OrderDTO>> result =
             service.viewSalesHistory(
                 STALE_USER_TOKEN,


### PR DESCRIPTION
refactored the tests for productioncompany service
added a map of user->children in production company as a way to more efficently gather all subordinantes
fixed incorrect req for see all revenue, as previously it would calc whole revenue for company, but req wants to only see revenue for caller subtree
still don't like dealing with tests