### PR TITLE
10 production company founding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,15 @@
 
     <build>
         <plugins>
+
+            <!-- Unit test runner -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
             </plugin>
 
+            <!-- Code formatting -->
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
@@ -116,7 +119,32 @@
                     </java>
                 </configuration>
             </plugin>
-            
+
+            <!-- ✅ Code coverage (JaCoCo) -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+
+                <executions>
+                    <!-- Attach agent before tests -->
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Generate report after tests -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/src/main/java/com/group16b/ApplicationLayer/DTOs/ProductionCompanyDTO.java
+++ b/src/main/java/com/group16b/ApplicationLayer/DTOs/ProductionCompanyDTO.java
@@ -5,6 +5,7 @@ public class ProductionCompanyDTO {
     private int id;
     private String name;
 
+
     public ProductionCompanyDTO() {
     }
 

--- a/src/main/java/com/group16b/ApplicationLayer/DTOs/ProductionCompanyDTO.java
+++ b/src/main/java/com/group16b/ApplicationLayer/DTOs/ProductionCompanyDTO.java
@@ -1,17 +1,25 @@
 package com.group16b.ApplicationLayer.DTOs;
 
+import java.util.List;
+
+import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
+
 public class ProductionCompanyDTO {
 
     private int id;
+    private double rating;
     private String name;
+    private String founderID;
+
+    private List<HierarchyNodeDTO> members;
 
 
-    public ProductionCompanyDTO() {
-    }
-
-    public ProductionCompanyDTO(int id, String name) {
-        this.id = id;
-        this.name = name;
+    public ProductionCompanyDTO(ProductionCompany company) {
+        this.id = company.getProductionCompanyID();
+        this.name = company.getName();
+        this.rating = company.getRating();
+        this.founderID = company.getFounderID();
+        this.members = company.getHierarchyTree(founderID).stream().map(HierarchyNodeDTO::new).toList();
     }
 
     public int getId() {
@@ -20,5 +28,17 @@ public class ProductionCompanyDTO {
 
     public String getName() {
         return name;
+    }
+
+    public double getRating() {
+        return rating;
+    }
+    public String getFounderID()
+    {
+        return founderID;
+    }
+
+    public List<HierarchyNodeDTO> getMembers() {
+        return members;
     }
 }

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -23,7 +23,6 @@ import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
 import com.group16b.DomainLayer.User.User;
 import com.group16b.InfrastructureLayer.IdGenerators.ProductionCompanyIdGen;
 
-import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -37,14 +36,15 @@ public class ProductionCompanyService {
     private final IProductionCompanyRepository productionRepo;
 	private final IAuthenticationService authenticationService;
 
-    private final ProductionCompanyIdGen idGen=new ProductionCompanyIdGen();
+    private final ProductionCompanyIdGen idGen;
 
-    public ProductionCompanyService(IAuthenticationService authenticationService,IRepository<Order> orderRepo, IEventRepository eventRepo, IRepository<User> userRepo, IProductionCompanyRepository productionRepo) {
+    public ProductionCompanyService(IAuthenticationService authenticationService,IRepository<Order> orderRepo, IEventRepository eventRepo, IRepository<User> userRepo, IProductionCompanyRepository productionRepo, ProductionCompanyIdGen idGen) {
         this.authenticationService = authenticationService;
         this.productionRepo=productionRepo;
         this.orderRepo=orderRepo;
         this.eventRepo=eventRepo;
         this.userRepo=userRepo;
+        this.idGen=idGen;
     }
 
     public Result<List<OrderDTO>> viewSalesHistory(String sessionToken, int productionCompanyID){
@@ -215,5 +215,6 @@ public class ProductionCompanyService {
         userRepo.findByID(userID);
         return userID;
     }
+    
 
 }

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -21,7 +21,9 @@ import com.group16b.DomainLayer.ProductionCompany.IProductionCompanyRepository;
 import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
 import com.group16b.DomainLayer.User.User;
+import com.group16b.InfrastructureLayer.IdGenerators.ProductionCompanyIdGen;
 
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -34,6 +36,8 @@ public class ProductionCompanyService {
     private final IRepository<User> userRepo;
     private final IProductionCompanyRepository productionRepo;
 	private final IAuthenticationService authenticationService;
+
+    private final ProductionCompanyIdGen idGen=new ProductionCompanyIdGen();
 
     public ProductionCompanyService(IAuthenticationService authenticationService,IRepository<Order> orderRepo, IEventRepository eventRepo, IRepository<User> userRepo, IProductionCompanyRepository productionRepo) {
         this.authenticationService = authenticationService;
@@ -116,7 +120,37 @@ public class ProductionCompanyService {
     }
 
     public Result<ProductionCompanyDTO> createProductionCompany(String sessionToken, String companyName) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        try{
+            logger.info("ProductionCompanyService.createProductionCompany: Creating production company with name {}",companyName);
+
+            String userID=validateAndGetUserID(sessionToken);
+            logger.info("ProductionCompanyService.createProductionCompany: Session token verified successfully.");
+
+            ProductionCompany newCompany = ProductionCompany.createNewCompany(companyName, userID, idGen.getNextId());
+            productionRepo.save(newCompany);
+
+            logger.info("ProductionCompanyService.createProductionCompany: Successfully created production company with name {}",companyName);
+            return Result.makeOk(new ProductionCompanyDTO(newCompany));
+
+        }catch(AuthException e)
+        {
+            logger.warn("ProductionCompanyService.createProductionCompany: Auth error: "+e.getMessage());
+            return Result.makeFail(e.getMessage());
+        } 
+        catch(IllegalArgumentException e)
+        {
+            logger.warn("ProductionCompanyService.createProductionCompany: IllegalArgumentException: "+e.getMessage());
+            return Result.makeFail(e.getMessage());
+        }
+        catch(OptimisticLockingFailureException e)
+        {
+            logger.warn("ProductionCompanyService.createProductionCompany: OptimisticLockException: "+e.getMessage());
+            return Result.makeFail("The production with this name already exists, please choose a different name.");
+        }
+        catch (Exception e) {
+            logger.error("ProductionCompanyService.createProductionCompany: Unexpected error",e);
+            return Result.makeFail("An unexpected error occurred: " + e.getMessage());
+        }
     }
 
     //gets all orders for the company

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -129,7 +129,7 @@ public class ProductionCompanyService {
             ProductionCompany newCompany = ProductionCompany.createNewCompany(companyName, userID, idGen.getNextId());
             productionRepo.save(newCompany);
 
-            logger.info("ProductionCompanyService.createProductionCompany: Successfully created production company with name {}",companyName);
+            logger.info("ProductionCompanyService.createProductionCompany: Successfully created production company with name {} and id {}",companyName, newCompany.getProductionCompanyID());
             return Result.makeOk(new ProductionCompanyDTO(newCompany));
 
         }catch(AuthException e)
@@ -141,11 +141,6 @@ public class ProductionCompanyService {
         {
             logger.warn("ProductionCompanyService.createProductionCompany: IllegalArgumentException: "+e.getMessage());
             return Result.makeFail(e.getMessage());
-        }
-        catch(OptimisticLockingFailureException e)
-        {
-            logger.warn("ProductionCompanyService.createProductionCompany: OptimisticLockException: "+e.getMessage());
-            return Result.makeFail("The production with this name already exists, please choose a different name.");
         }
         catch (Exception e) {
             logger.error("ProductionCompanyService.createProductionCompany: Unexpected error",e);

--- a/src/main/java/com/group16b/ApplicationLayer/StartupService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/StartupService.java
@@ -18,6 +18,7 @@ import com.group16b.InfrastructureLayer.MapDBs.VenueRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.VirtualQueueRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.PaymentService;
 import com.group16b.InfrastructureLayer.TicketGateway;
+import com.group16b.InfrastructureLayer.IdGenerators.ProductionCompanyIdGen;
 
 public class StartupService {
     private final static Logger logger = LoggerFactory.getLogger(StartupService.class);
@@ -30,6 +31,7 @@ public class StartupService {
     private final ReserveService reserveService;
     private final UserLoginService userLoginService;
     private final UserService userService;
+    private final ProductionCompanyIdGen productionCompanyIdGen;
 
 
     public StartupService() {
@@ -45,6 +47,7 @@ public class StartupService {
         SystemAdminRepositoryMapImpl systemAdminRepositoryMapImpl = new SystemAdminRepositoryMapImpl();
         PaymentService paymentService = new PaymentService();
         TicketGateway ticketGateway = new TicketGateway();
+        productionCompanyIdGen=new ProductionCompanyIdGen();
 
         logger.info("Initializing domain services...");
         EventFilteringService eventFilteringService = new EventFilteringService(productionCompanyRepositoryMapImpl, eventRepositoryMapImpl, venueRepositoryMapImpl);
@@ -55,7 +58,7 @@ public class StartupService {
         companyHierarchyService = new CompanyHierarchyService(authService,productionCompanyRepositoryMapImpl, userRepositoryMapImpl);
         eventService = new EventService(authService, locationService, eventFilteringService, productionCompanyRepositoryMapImpl, queueRepositoryMapImpl, venueRepositoryMapImpl, eventRepositoryMapImpl, userRepositoryMapImpl);
         orderService = new OrderService(authService,productionCompanyRepositoryMapImpl, paymentService, venueRepositoryMapImpl, eventRepositoryMapImpl, userRepositoryMapImpl, orderRepositoryMapImpl, ticketGateway);
-        productionCompanyService = new ProductionCompanyService(authService,orderRepositoryMapImpl,eventRepositoryMapImpl,userRepositoryMapImpl,productionCompanyRepositoryMapImpl);
+        productionCompanyService = new ProductionCompanyService(authService,orderRepositoryMapImpl,eventRepositoryMapImpl,userRepositoryMapImpl,productionCompanyRepositoryMapImpl,productionCompanyIdGen);
         purchasePolicyService = new PurchasePolicyService(authService,productionCompanyRepositoryMapImpl, eventRepositoryMapImpl, userRepositoryMapImpl);
         reserveService = new ReserveService(authService,productionCompanyRepositoryMapImpl, queueRepositoryMapImpl, venueRepositoryMapImpl, eventRepositoryMapImpl, orderRepositoryMapImpl);
         userLoginService = new UserLoginService(userRepositoryMapImpl, authService);

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
@@ -54,12 +54,20 @@ public class ProductionCompany {
     }
     public ProductionCompany(int id, String name, double rating, String founderID)
     {
+        if(name==null || name.isEmpty())
+        {
+            throw new IllegalArgumentException("Production company name cannot be empty.");
+        }
         this.rating=rating;
         this.name=name;
         this.productionCompanyID=id;
         this.version=1;
         this.founderID= founderID;
         this.membersNodes.put(founderID,MembershipNode.createFounder(founderID));
+    }
+    public static ProductionCompany createNewCompany(String name, String founderID, int id)
+    {
+        return new ProductionCompany(id,name,0.0,founderID);
     }
 
 
@@ -74,6 +82,10 @@ public class ProductionCompany {
     public String getName()
     {
         return name;
+    }
+    public String getFounderID()
+    {
+        return founderID;
     }
     public void setName(String name)
     {

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
@@ -54,16 +54,26 @@ public class ProductionCompany {
     }
     public ProductionCompany(int id, String name, double rating, String founderID)
     {
-        if(name==null || name.isEmpty())
-        {
-            throw new IllegalArgumentException("Production company name cannot be empty.");
-        }
+        this.name=normalizeCompanyName(name);
         this.rating=rating;
-        this.name=name;
         this.productionCompanyID=id;
         this.version=1;
         this.founderID= founderID;
         this.membersNodes.put(founderID,MembershipNode.createFounder(founderID));
+    }
+
+    private String normalizeCompanyName(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("Production company name cannot be empty.");
+        }
+
+        String trimmed = name.trim();
+
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Production company name cannot be empty.");
+        }
+
+        return trimmed;
     }
     public static ProductionCompany createNewCompany(String name, String founderID, int id)
     {
@@ -96,6 +106,7 @@ public class ProductionCompany {
     {
         return version;
     }
+
     public void setVersion(long version)
     {
         this.version=version;

--- a/src/main/java/com/group16b/InfrastructureLayer/IdGenerators/ProductionCompanyIdGen.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/IdGenerators/ProductionCompanyIdGen.java
@@ -1,0 +1,15 @@
+package com.group16b.InfrastructureLayer.IdGenerators;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ProductionCompanyIdGen {
+    private final AtomicInteger currentId=new AtomicInteger(0);
+    
+    public void seed(int seed) {
+        currentId.set(seed);
+    }
+
+    public int getNextId() {
+        return currentId.incrementAndGet();
+    }
+}

--- a/src/main/java/com/group16b/InfrastructureLayer/IdGenerators/ProductionCompanyIdGen.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/IdGenerators/ProductionCompanyIdGen.java
@@ -2,6 +2,9 @@ package com.group16b.InfrastructureLayer.IdGenerators;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class ProductionCompanyIdGen {
     private final AtomicInteger currentId=new AtomicInteger(0);
     

--- a/src/main/java/com/group16b/InfrastructureLayer/MapDBs/ProductionCompanyRepositoryMapImpl.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/MapDBs/ProductionCompanyRepositoryMapImpl.java
@@ -34,6 +34,9 @@ public class ProductionCompanyRepositoryMapImpl implements IProductionCompanyRep
 
     @Override
     public int getIDByName(String name) {
+        if(name == null) {
+            throw new IllegalArgumentException("Company name cannot be null.");
+        }
         Integer id = names.get(name);
         if(id == null) {
              throw new IllegalArgumentException("Production company with name " + name + " is not found.");

--- a/src/main/java/com/group16b/InfrastructureLayer/MapDBs/ProductionCompanyRepositoryMapImpl.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/MapDBs/ProductionCompanyRepositoryMapImpl.java
@@ -12,7 +12,6 @@ import com.group16b.DomainLayer.User.User;
 import org.springframework.stereotype.Repository;
 
 @Repository
-
 public class ProductionCompanyRepositoryMapImpl implements IProductionCompanyRepository {
 
     // source of truth
@@ -57,6 +56,9 @@ public class ProductionCompanyRepositoryMapImpl implements IProductionCompanyRep
         ProductionCompany removed = companies.remove(id);
         if(removed != null) {
             names.remove(removed.getName());
+        }
+        else {
+            throw new IllegalArgumentException("Production company with ID " + ID + " is not found.");
         }
     }
 

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -5,15 +5,22 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
 import com.group16b.ApplicationLayer.DTOs.ProductionCompanyDTO;
@@ -28,6 +35,7 @@ import com.group16b.DomainLayer.ProductionCompany.IProductionCompanyRepository;
 import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
 import com.group16b.DomainLayer.User.User;
+import com.group16b.InfrastructureLayer.IdGenerators.ProductionCompanyIdGen;
 import com.group16b.InfrastructureLayer.MapDBs.EventRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.OrderRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.ProductionCompanyRepositoryMapImpl;
@@ -55,6 +63,8 @@ public class ProductionCompanyServiceTests {
     private User non_manager;
     private User owner;
 
+    private ProductionCompanyIdGen idGen;
+
     private final String VALID_FOUNDER_TOKEN = "valid-foudner-token";
     private final String VALID_HISTORY_MANAGER_TOKEN = "valid-history-manager-token";
     private final String VALID_REVENUE_MANAGER_TOKEN = "valid-revenue-manager-token";
@@ -77,6 +87,7 @@ public class ProductionCompanyServiceTests {
     private final String FOUNDER_EMAIL="founder@example.com";
     private final String COMPANY1_NAME="Company1";
     private final String COMPANY2_NAME="Company2";
+    private final String BAD_COMPANY_NAME="new company";
     
 
     private Event company1Event1;
@@ -132,12 +143,16 @@ public class ProductionCompanyServiceTests {
         userRepo = new UserRepositoryMapImpl();
         companyRepo = new ProductionCompanyRepositoryMapImpl();
 
+        idGen = new ProductionCompanyIdGen();
+        idGen=Mockito.spy(idGen);
+
         service = new ProductionCompanyService(
             authService,
             orderRepo,
             eventRepo,
             userRepo,
-            companyRepo
+            companyRepo,
+            idGen
         );
 
         seedBaseData();
@@ -604,23 +619,23 @@ public class ProductionCompanyServiceTests {
 
     @Test
     void createCompany_ValidFounderAndName_ReturnsSuccess() {
-        String newCompanyName = "New Company";
         Result<ProductionCompanyDTO> result =
             service.createProductionCompany(
                 VALID_FOUNDER_TOKEN,
-                newCompanyName
+                BAD_COMPANY_NAME
             );
 
         assertTrue(result.isSuccess());
         ProductionCompanyDTO dto = result.getValue();
-        assertEquals(newCompanyName, dto.getName());
+        assertEquals(BAD_COMPANY_NAME, dto.getName());
         assertEquals(FOUNDER_EMAIL, dto.getFounderID());
         assertTrue(dto.getId() > 0);
         assertTrue(dto.getMembers().size()==1);
         assertEquals(FOUNDER_EMAIL, dto.getMembers().get(0).getUserId());
         assertEquals(null,dto.getMembers().get(0).getAssignerId());
 
-        assertEquals(companyRepo.getIDByName(newCompanyName), dto.getId());
+        assertEquals(companyRepo.getIDByName(BAD_COMPANY_NAME), dto.getId());
+        verify(idGen, times(1)).getNextId();
     }
 
     @Test
@@ -634,6 +649,7 @@ public class ProductionCompanyServiceTests {
         assertFalse(result.isSuccess());
         assertTrue(result.getError().contains("already exists"));
         assertEquals(company1.getProductionCompanyID(), companyRepo.getIDByName(COMPANY1_NAME));
+        verify(idGen, times(1)).getNextId();
     }
 
     @Test
@@ -647,6 +663,7 @@ public class ProductionCompanyServiceTests {
         assertFalse(result.isSuccess());
         assertEquals("Production company name cannot be empty.", result.getError());
         assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName(null));
+        verify(idGen, times(1)).getNextId();
     }
 
     @Test
@@ -660,6 +677,21 @@ public class ProductionCompanyServiceTests {
         assertFalse(result.isSuccess());
         assertEquals("Production company name cannot be empty.", result.getError());
         assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName(null));
+        verify(idGen, times(1)).getNextId();
+    }
+
+    @Test
+    void createCompany_blankCompanyName_ReturnsFailure() {
+        Result<ProductionCompanyDTO> result =
+            service.createProductionCompany(
+                VALID_FOUNDER_TOKEN,
+                "   "
+            );
+
+        assertFalse(result.isSuccess());
+        assertEquals("Production company name cannot be empty.", result.getError());
+        assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName("   "));
+        verify(idGen, times(1)).getNextId();
     }
 
     @Test
@@ -667,12 +699,13 @@ public class ProductionCompanyServiceTests {
         Result<ProductionCompanyDTO> result =
             service.createProductionCompany(
                 INVALID_TOKEN,
-                "Some Company Name"
+                BAD_COMPANY_NAME
             );
 
         assertFalse(result.isSuccess());
         assertEquals("Invalid Token", result.getError());
-        assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName("Some Company Name"));
+        assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName(BAD_COMPANY_NAME));
+        verify(idGen, times(0)).getNextId();
     }
 
      @Test
@@ -680,7 +713,7 @@ public class ProductionCompanyServiceTests {
          Result<ProductionCompanyDTO> result =
              service.createProductionCompany(
                  STALE_USER_TOKEN,
-                 "Some Company Name"
+                 BAD_COMPANY_NAME
              );
 
          assertFalse(result.isSuccess());
@@ -688,8 +721,115 @@ public class ProductionCompanyServiceTests {
              "User with ID " + BAD_USER_ID + " not found.",
              result.getError()
          );
-         assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName("Some Company Name"));
-     }
+         assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName(BAD_COMPANY_NAME));
+         verify(idGen, times(0)).getNextId();
+    }
+
+    @Test
+    void concurrentCreateSameName_onlyOneSucceeds() throws Exception {
+        String companyName = BAD_COMPANY_NAME; // name that doesn't exist yet
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        Runnable task = () -> {
+            try {
+                start.await();
+
+                Result<ProductionCompanyDTO> result =
+                    service.createProductionCompany(VALID_FOUNDER_TOKEN, companyName);
+
+                if (result.isSuccess()) {
+                    successCount.incrementAndGet();
+                } else {
+                    failCount.incrementAndGet();
+                }
+
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                done.countDown();
+            }
+        };
+
+        executor.submit(task);
+        executor.submit(task);
+
+        start.countDown();   // release both threads at same time
+        done.await();
+
+        executor.shutdown();
+
+        assertEquals(1, successCount.get());
+        assertEquals(1, failCount.get());
+        assertEquals(companyRepo.findByID(String.valueOf(companyRepo.getIDByName(companyName))).getName(), BAD_COMPANY_NAME);
+    }
+
+    @Test
+    void concurrentCreateDifferentNames_bothSucceed() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        Runnable task1 = () -> {
+            try {
+                start.await();
+
+                Result<ProductionCompanyDTO> result =
+                    service.createProductionCompany(VALID_FOUNDER_TOKEN, "new1");
+
+                if (result.isSuccess()) successCount.incrementAndGet();
+                else failCount.incrementAndGet();
+
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                done.countDown();
+            }
+        };
+
+        Runnable task2 = () -> {
+            try {
+                start.await();
+
+                Result<ProductionCompanyDTO> result =
+                    service.createProductionCompany(VALID_FOUNDER_TOKEN, "new2");
+
+                if (result.isSuccess()) successCount.incrementAndGet();
+                else failCount.incrementAndGet();
+
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                done.countDown();
+            }
+        };
+
+        executor.submit(task1);
+        executor.submit(task2);
+
+        start.countDown();
+        done.await();
+
+        executor.shutdown();
+
+        assertEquals(2, successCount.get());
+        assertEquals(0, failCount.get());
+        assertEquals(companyRepo.findByID(String.valueOf(companyRepo.getIDByName("new1"))).getName(), "new1");
+        assertEquals(companyRepo.findByID(String.valueOf(companyRepo.getIDByName("new2"))).getName(), "new2");
+    }
+
+
+    
 
 
 

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -662,6 +662,35 @@ public class ProductionCompanyServiceTests {
         assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName(null));
     }
 
+    @Test
+    void createCompany_invalidFounderToken_ReturnsFailure() {
+        Result<ProductionCompanyDTO> result =
+            service.createProductionCompany(
+                INVALID_TOKEN,
+                "Some Company Name"
+            );
+
+        assertFalse(result.isSuccess());
+        assertEquals("Invalid Token", result.getError());
+        assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName("Some Company Name"));
+    }
+
+     @Test
+     void createCompany_staleFounderToken_ReturnsFailure() {
+         Result<ProductionCompanyDTO> result =
+             service.createProductionCompany(
+                 STALE_USER_TOKEN,
+                 "Some Company Name"
+             );
+
+         assertFalse(result.isSuccess());
+         assertEquals(
+             "User with ID " + BAD_USER_ID + " not found.",
+             result.getError()
+         );
+         assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName("Some Company Name"));
+     }
+
 
 
 

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
+import com.group16b.ApplicationLayer.DTOs.ProductionCompanyDTO;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.ApplicationLayer.Objects.Result;
 import com.group16b.ApplicationLayer.Records.EventRecord;
@@ -598,6 +599,27 @@ public class ProductionCompanyServiceTests {
         assertEquals(0.0, result.getValue());
 
         assertRepositoriesUnchanged();
+    }
+
+    @Test
+    void createCompany_ValidFounderAndName_ReturnsSuccess() {
+        String newCompanyName = "New Company";
+        Result<ProductionCompanyDTO> result =
+            service.createProductionCompany(
+                VALID_FOUNDER_TOKEN,
+                newCompanyName
+            );
+
+        assertTrue(result.isSuccess());
+        ProductionCompanyDTO dto = result.getValue();
+        assertEquals(newCompanyName, dto.getName());
+        assertEquals(FOUNDER_EMAIL, dto.getFounderID());
+        assertTrue(dto.getId() > 0);
+        assertTrue(dto.getMembers().size()==1);
+        assertEquals(FOUNDER_EMAIL, dto.getMembers().get(0).getUserId());
+        assertEquals(null,dto.getMembers().get(0).getAssignerId());
+
+        assertEquals(companyRepo.getIDByName(newCompanyName), dto.getId());
     }
 
 

--- a/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/ProductionCompanyServiceTests.java
@@ -2,6 +2,7 @@ package com.group16b.ApplicationLayer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -621,6 +622,47 @@ public class ProductionCompanyServiceTests {
 
         assertEquals(companyRepo.getIDByName(newCompanyName), dto.getId());
     }
+
+    @Test
+    void createCompany_duplicateCompanyName_ReturnsFailure() {
+        Result<ProductionCompanyDTO> result =
+            service.createProductionCompany(
+                VALID_FOUNDER_TOKEN,
+                COMPANY1_NAME
+            );
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("already exists"));
+        assertEquals(company1.getProductionCompanyID(), companyRepo.getIDByName(COMPANY1_NAME));
+    }
+
+    @Test
+    void createCompany_nullCompanyName_ReturnsFailure() {
+        Result<ProductionCompanyDTO> result =
+            service.createProductionCompany(
+                VALID_FOUNDER_TOKEN,
+                null
+            );
+
+        assertFalse(result.isSuccess());
+        assertEquals("Production company name cannot be empty.", result.getError());
+        assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName(null));
+    }
+
+    @Test
+    void createCompany_emptyCompanyName_ReturnsFailure() {
+        Result<ProductionCompanyDTO> result =
+            service.createProductionCompany(
+                VALID_FOUNDER_TOKEN,
+                ""
+            );
+
+        assertFalse(result.isSuccess());
+        assertEquals("Production company name cannot be empty.", result.getError());
+        assertThrows(IllegalArgumentException.class, () -> companyRepo.getIDByName(null));
+    }
+
+
 
 
 }

--- a/src/test/java/com/group16b/infrastructureLayer/MapDBs/ProductionCompanyRepositoryMapImplTests.java
+++ b/src/test/java/com/group16b/infrastructureLayer/MapDBs/ProductionCompanyRepositoryMapImplTests.java
@@ -281,9 +281,11 @@ public class ProductionCompanyRepositoryMapImplTests {
     }
 
     @Test
-    void delete_nonExistingCompany_doesNothing() {
-        repo.delete("999");
-        assertTrue(repo.getAll().isEmpty());
+    void delete_nonExistingCompany_ThrowsIllegalArgumentException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> repo.delete("999")
+        );
     }
 
     @Test


### PR DESCRIPTION
added the ability to create production companies
created an id generator, that currently company exclusive but can be easily adapted for any aggregate with id
maybe it would be even better to instead of relying on company id, just go by name=id like with user mails, but that potentially will be on the level of user id refactor so idk
added tests
added jacoco to project, dont have mvn so im unable to check if it works, but apearently mvn test should produce some jacoco directory in target, where it will display covarage
hopefully didnt forget anything important
