### PR TITLE
359 changepassword in service doesnt catch all error types

### DIFF
--- a/src/main/java/com/group16b/ApplicationLayer/UserService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/UserService.java
@@ -95,12 +95,14 @@ public class UserService {
             userRepo.save(user);
             logger.info("UserService.updateUserPassword: Password changed successfully.");
             return Result.makeOk(true);
-            
+        } catch (IllegalArgumentException e) {
+            logger.warn("UserService.updateUserPassword: IllegalArgumentException: " + e.getMessage());
+            return Result.makeFail(e.getMessage());
         } catch (JwtException e) {
-			logger.error("JWT authentication error during user password update: " + e.getMessage());
+			logger.error("UserService.updateUserPassword: JWT authentication error during user password update: " + e.getMessage());
 			return Result.makeFail("Authentication failed: " + e.getMessage());
 		} catch (Exception e) {
-			logger.error("Unexpected error during user password update: " + e.getMessage());
+			logger.error("UserService.updateUserPassword: Unexpected error during user password update: " + e.getMessage());
 			return Result.makeFail("An unexpected error occurred: " + e.getMessage());
 		}
 	}
@@ -131,16 +133,17 @@ public class UserService {
 
             logger.info("UserService.getUserOrderHistory: Successfully retrieved order history.");
             return Result.makeOk(orderDTOs);        
-            
+        } catch (IllegalArgumentException e) {
+            logger.warn("UserService.getUserOrderHistory: IllegalArgumentException: " + e.getMessage());
+            return Result.makeFail(e.getMessage());    
         } catch (AuthException e) {
             logger.warn("UserService.getUserOrderHistory: Authentication failed during order history fetch: " + e.getMessage());
             return Result.makeFail("Authentication failed: " + e.getMessage());
-        }
-        catch (JwtException e) {
-            logger.error("JWT authentication error during user order history fetch: " + e.getMessage());
+        } catch (JwtException e) {
+            logger.error("UserService.getUserOrderHistory: JWT authentication error during user order history fetch: " + e.getMessage());
             return Result.makeFail("Authentication failed: " + e.getMessage());
         } catch (Exception e) {
-            logger.error("Unexpected error during user order history fetch: " + e.getMessage());
+            logger.error("UserService.getUserOrderHistory: Unexpected error during user order history fetch: " + e.getMessage());
             return Result.makeFail("An unexpected error occurred: " + e.getMessage());
         }
     }

--- a/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
@@ -126,7 +126,7 @@ public class UserServiceTests {
         Result<Boolean> result = userService.updateUserPassword(token, "WrongPassword!", "NewPassword456!");
 
         assertFalse(result.isSuccess());
-        assertEquals("An unexpected error occurred: Old password is incorrect.", result.getError());
+        assertEquals("Old password is incorrect.", result.getError());
 
         User untouchedUser = userRepo.findByID("member@test.com");
         assertTrue(untouchedUser.confirmPassword("OldPassword123!"));


### PR DESCRIPTION
added the missing catch
hope i didnt miss other missing catches
fixed exception login by adding the function name to the log
Probably a good idea to use the verifyTokenAndGetId instead of the repetetive checks so feel free to tell me