### PR TITLE
453 lottery policy refactor

### DIFF
--- a/src/main/java/com/group16b/ApplicationLayer/PurchasePolicyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/PurchasePolicyService.java
@@ -100,6 +100,9 @@ public class PurchasePolicyService {
         } catch (IllegalArgumentException e) {
             logger.error("PurchasePolicyService.createLotteryPolicy: " + e.getMessage());
             return Result.makeFail(e.getMessage());
+        } catch (IllegalStateException e) {
+            logger.error("PurchasePolicyService.createLotteryPolicy: " + e.getMessage());
+            return Result.makeFail(e.getMessage());
         } catch (Exception e) {
             logger.error(
                     "PurchasePolicyService.createLotteryPolicy: An unexpected error occurred while creating a lottery"

--- a/src/main/java/com/group16b/ApplicationLayer/PurchasePolicyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/PurchasePolicyService.java
@@ -84,7 +84,7 @@ public class PurchasePolicyService {
 
                 logger.info("PurchasePolicyService.createLotteryPolicy: Adding lottery policy to event with ID: {}",
                         eventID);
-                e.addEventPurchasePolicy(lotteryPolicy);
+                e.setLotteryPolicy(lotteryPolicy);
 
                 logger.info("PurchasePolicyService.createLotteryPolicy: saving changes to repository");
                 try {

--- a/src/main/java/com/group16b/DomainLayer/Event/Event.java
+++ b/src/main/java/com/group16b/DomainLayer/Event/Event.java
@@ -24,6 +24,7 @@ public class Event {
 	private final int productionCompanyID;
 	private final Set<DiscountPolicy> discountPolicy;
 	private final Set<PurchasePolicy> purchasePolicy;
+	private LotteryPolicy lotteryPolicy;
 	private double price;
 	private double rating;
 	private final String ownerId;
@@ -51,6 +52,7 @@ public class Event {
 		this.rating = eventRecord.rating();
 		this.ownerId = ownerId;
 		this.version = 0;
+		lotteryPolicy = null;
 	}
 
 	public Event(Event other) {
@@ -69,6 +71,7 @@ public class Event {
 		this.rating = other.getEventRating();
 		this.ownerId = other.getOwnerId();
 		this.version = other.getVersion();
+		lotteryPolicy = new LotteryPolicy(other.getLotteryPolicy());
 	}
 
 	private Set<DiscountPolicy> copyDiscountPolicies(Set<DiscountPolicy> policies) {
@@ -218,12 +221,17 @@ public class Event {
 
 	// lottery
 	public LotteryPolicy getLotteryPolicy() throws IllegalStateException {
-		LotteryPolicy lp = purchasePolicy.stream().filter(pp -> pp instanceof LotteryPolicy).findFirst()
-				.map(pp -> ((LotteryPolicy) pp)).orElse(null);
-		if (lp == null) {
+		if (lotteryPolicy == null) {
 			throw new IllegalStateException("Event does not have a lottery policy.");
 		}
-		return lp;
+		return lotteryPolicy;
+	}
+
+	public void setLotteryPolicy(LotteryPolicy lotteryPolicy) {
+		if (this.lotteryPolicy != null) {
+			throw new IllegalStateException("Event already has a lottery policy.");
+		}
+		this.lotteryPolicy = lotteryPolicy;
 	}
 
 	public void validateLotteryCode(String lotteryCode) throws IllegalStateException {

--- a/src/main/java/com/group16b/DomainLayer/Event/Event.java
+++ b/src/main/java/com/group16b/DomainLayer/Event/Event.java
@@ -224,14 +224,14 @@ public class Event {
 		if (lotteryPolicy == null) {
 			throw new IllegalStateException("Event does not have a lottery policy.");
 		}
-		return lotteryPolicy;
+		return new LotteryPolicy(lotteryPolicy);
 	}
 
 	public void setLotteryPolicy(LotteryPolicy lotteryPolicy) {
 		if (this.lotteryPolicy != null) {
 			throw new IllegalStateException("Event already has a lottery policy.");
 		}
-		this.lotteryPolicy = lotteryPolicy;
+		this.lotteryPolicy = new LotteryPolicy(lotteryPolicy);
 	}
 
 	public void validateLotteryCode(String lotteryCode) throws IllegalStateException {

--- a/src/main/java/com/group16b/DomainLayer/Event/Event.java
+++ b/src/main/java/com/group16b/DomainLayer/Event/Event.java
@@ -224,7 +224,7 @@ public class Event {
 		if (lotteryPolicy == null) {
 			throw new IllegalStateException("Event does not have a lottery policy.");
 		}
-		return new LotteryPolicy(lotteryPolicy);
+		return lotteryPolicy;
 	}
 
 	public void setLotteryPolicy(LotteryPolicy lotteryPolicy) {

--- a/src/main/java/com/group16b/DomainLayer/Event/Event.java
+++ b/src/main/java/com/group16b/DomainLayer/Event/Event.java
@@ -71,7 +71,7 @@ public class Event {
 		this.rating = other.getEventRating();
 		this.ownerId = other.getOwnerId();
 		this.version = other.getVersion();
-		lotteryPolicy = new LotteryPolicy(other.getLotteryPolicy());
+		lotteryPolicy = other.lotteryPolicy == null ? null : new LotteryPolicy(other.getLotteryPolicy());
 	}
 
 	private Set<DiscountPolicy> copyDiscountPolicies(Set<DiscountPolicy> policies) {

--- a/src/main/java/com/group16b/DomainLayer/Event/Event.java
+++ b/src/main/java/com/group16b/DomainLayer/Event/Event.java
@@ -231,7 +231,7 @@ public class Event {
 		if (this.lotteryPolicy != null) {
 			throw new IllegalStateException("Event already has a lottery policy.");
 		}
-		this.lotteryPolicy = new LotteryPolicy(lotteryPolicy);
+		this.lotteryPolicy = lotteryPolicy;
 	}
 
 	public void validateLotteryCode(String lotteryCode) throws IllegalStateException {

--- a/src/test/java/com/group16b/ApplicationLayer/PurchasePolicyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/PurchasePolicyServiceTests.java
@@ -250,10 +250,13 @@ public class PurchasePolicyServiceTests {
             successCount++;
         }
 
-        assertTrue(successCount == 2);
+        assertTrue(successCount == 1);
 
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         assertDoesNotThrow(() -> e.getLotteryPolicy());
+
+        Result<Boolean> errorResult = result1.get().isSuccess() ? result2.get() : result1.get();
+        assertEquals("Event already has a lottery policy.", errorResult.getError());
     }
 
     @Test
@@ -284,7 +287,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_FailNotUserToken() {
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        e.addEventPurchasePolicy(lotteryPolicy);
+        e.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(e);
         Result<Boolean> res = purchasePolicyService.enrollInLottery("guest", e1.getEventID());
         assertFalse(res.isSuccess());
@@ -296,7 +299,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_FailUserNotFound() {
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        e.addEventPurchasePolicy(lotteryPolicy);
+        e.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(e);
         userRepository.delete("testuser");
         Result<Boolean> res = purchasePolicyService.enrollInLottery("user1", e1.getEventID());
@@ -309,7 +312,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_FailEventNotFound() {
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        e.addEventPurchasePolicy(lotteryPolicy);
+        e.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(e);
         Result<Boolean> res = purchasePolicyService.enrollInLottery("user1", 999);
         assertFalse(res.isSuccess());
@@ -321,7 +324,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_FailInactiveEvent() {
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        e.addEventPurchasePolicy(lotteryPolicy);
+        e.setLotteryPolicy(lotteryPolicy);
         e.deactivateEvent();
         eventRepository.save(e);
         Result<Boolean> res = purchasePolicyService.enrollInLottery("user1", e1.getEventID());
@@ -334,7 +337,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_FailPastEnrollDate() throws InterruptedException {
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusSeconds(1));
-        e.addEventPurchasePolicy(lotteryPolicy);
+        e.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(e);
         Thread.sleep(1000);
         Result<Boolean> res = purchasePolicyService.enrollInLottery("user1", e1.getEventID());
@@ -347,7 +350,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_FailEnrollTwice() {
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        e.addEventPurchasePolicy(lotteryPolicy);
+        e.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(e);
         Result<Boolean> res = purchasePolicyService.enrollInLottery("user1", e1.getEventID());
         assertTrue(res.isSuccess());
@@ -363,7 +366,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_TwoThreadsBothSucceeds() throws InterruptedException {
         Event eve = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        eve.addEventPurchasePolicy(lotteryPolicy);
+        eve.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(eve);
 
         CountDownLatch readyLatch = new CountDownLatch(2);
@@ -429,7 +432,7 @@ public class PurchasePolicyServiceTests {
     public void createLotteryPolicy_TwoThreadsOneSucceeds() throws InterruptedException {
         Event eve = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        eve.addEventPurchasePolicy(lotteryPolicy);
+        eve.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(eve);
 
         CountDownLatch readyLatch = new CountDownLatch(2);

--- a/src/test/java/com/group16b/ApplicationLayer/PurchasePolicyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/PurchasePolicyServiceTests.java
@@ -260,7 +260,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_Success() {
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        e.addEventPurchasePolicy(lotteryPolicy);
+        e.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(e);
         Result<Boolean> res = purchasePolicyService.enrollInLottery("user1", e1.getEventID());
         assertTrue(res.isSuccess());
@@ -272,7 +272,7 @@ public class PurchasePolicyServiceTests {
     public void enrollLotteryPolicy_FailInvalidToken() {
         Event e = eventRepository.findByID(Integer.toString(e1.getEventID()));
         LotteryPolicy lotteryPolicy = new LotteryPolicy(0, "Lottery", 50, now.plusDays(5));
-        e.addEventPurchasePolicy(lotteryPolicy);
+        e.setLotteryPolicy(lotteryPolicy);
         eventRepository.save(e);
         Result<Boolean> res = purchasePolicyService.enrollInLottery("invalid_token", e1.getEventID());
         assertFalse(res.isSuccess());

--- a/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
@@ -6,13 +6,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
+import com.group16b.ApplicationLayer.DTOs.ProductionCompanyDTO;
 import com.group16b.ApplicationLayer.DTOs.UserDTO;
+import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.ApplicationLayer.Objects.Result;
 import com.group16b.DomainLayer.Order.Order;
+import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.User.SessionToken;
 import com.group16b.DomainLayer.User.User;
 import com.group16b.InfrastructureLayer.AuthenticationServiceJWTImpl;
@@ -32,6 +39,17 @@ public class UserServiceTests {
     private String noOrdersToken;
     private String guestToken;
     private String adminToken;
+    private String noCompaniesToken;
+    private String nonExistentUserToken;
+
+    private final int USER_COMPANY_ID=1;
+    private final int USER_COMPANY_ID_2=3;
+    private final int NON_USER_COMPANY_ID=999;
+
+    private final String USER_EMAIL = "test2@test.com";
+    private final String OTHER_USER_EMAIL = "noorders@test.com";
+    private final String NO_COMPANY_USER_EMAIL = "no-comps@wa.com";
+    private final String NON_EXISTENT_USER_EMAIL = "birds are fake";
 
 
 @BeforeEach
@@ -53,11 +71,13 @@ public class UserServiceTests {
         userService = new UserService(authService, ticketGateway, venueRepo, userRepo, orderRepo, eventRepo, productionCompanyRepository);
 
         // for get user order history tests, we need to have a user with orders in the repo and a valid token for that user
-        sessionToken = authService.generateVisitor_SignedToken("test2@test.com");
+        sessionToken = authService.generateVisitor_SignedToken(USER_EMAIL);
         noOrdersToken = authService.generateVisitor_SignedToken("noorders@test.com");
+        noCompaniesToken = authService.generateVisitor_SignedToken(NO_COMPANY_USER_EMAIL);
         guestToken = authService.generateVisitor_GuestToken(new SessionToken("guest-session"));
         adminToken = authService.generateAdminToken("admin@test.com");
-        User tUser = new User("test2@test.com", "Password123!");
+        nonExistentUserToken = authService.generateVisitor_SignedToken(NON_EXISTENT_USER_EMAIL);
+        User tUser = new User(USER_EMAIL, "Password123!");
         userRepo.save(tUser);
         Order orderSeat1 = new Order( "seg1", List.of("A1", "A2"), 100.0, 1, "test2@test.com");
         orderSeat1.CompleteOrder();
@@ -85,6 +105,14 @@ public class UserServiceTests {
         otherOrder2.CompleteOrder();
         orderRepo.save(otherOrder2);
 
+        ProductionCompany company1 = new ProductionCompany(USER_COMPANY_ID, "User's Company",0.0,USER_EMAIL);
+        ProductionCompany company2 = new ProductionCompany(NON_USER_COMPANY_ID, "Non User's Company",0.0,OTHER_USER_EMAIL);
+        ProductionCompany company3 = new ProductionCompany(USER_COMPANY_ID_2, "Other Company",0.0,USER_EMAIL);
+        productionCompanyRepository.save(company1);
+        productionCompanyRepository.save(company2);
+        productionCompanyRepository.save(company3);
+
+        userRepo.save(new User(NO_COMPANY_USER_EMAIL, "Password123!"));
     }
 
     @Test
@@ -221,5 +249,79 @@ public class UserServiceTests {
         assertTrue(result.isSuccess());
         assertNotNull(result.getValue());
         assertEquals(5, result.getValue().size());
+    }
+
+    @Test
+    void getAllUserCompanies_validUserToken_returnsNonEmptyCompanyList() {
+        Result<List<ProductionCompanyDTO>> result = userService.getAllUserCompanies(sessionToken);
+
+        assertTrue(result.isSuccess());
+        assertNotNull(result.getValue());
+        assertEquals(2, result.getValue().size());
+        assertTrue(result.getValue().stream().anyMatch(c -> c.getId() == USER_COMPANY_ID));
+        assertTrue(result.getValue().stream().anyMatch(c -> c.getId() == USER_COMPANY_ID_2));
+    }
+
+    @Test
+    void getAllUserCompanies_validUserTokenWithNoCompanies_returnsEmptyCompanyList() {
+        Result<List<ProductionCompanyDTO>> result = userService.getAllUserCompanies(noCompaniesToken);
+
+        assertTrue(result.isSuccess());
+        assertNotNull(result.getValue());
+        assertEquals(0, result.getValue().size());
+    }
+
+    @Test
+    void getAllUserCompanies_guestToken_returnsFail() {
+        Result<List<ProductionCompanyDTO>> result = userService.getAllUserCompanies(guestToken);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Authentication failed: Only users are allowed to perform operation", result.getError());
+    }
+
+    @Test
+    void getAllUserCompanies_adminToken_returnsFail() {
+        Result<List<ProductionCompanyDTO>> result = userService.getAllUserCompanies(adminToken);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Authentication failed: Only users are allowed to perform operation", result.getError());
+    }
+
+    @Test
+    void getAllUserCompanies_invalidToken_returnsFail() {
+        String invalidToken = "this-is-not-a-real-token-because-chaos";
+
+        Result<List<ProductionCompanyDTO>> result = userService.getAllUserCompanies(invalidToken);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Authentication failed: Invalid Token", result.getError());
+    }
+
+    @Test
+    void getAllUserCompanies_nullToken_returnsFail() {
+        Result<List<ProductionCompanyDTO>> result = userService.getAllUserCompanies(null);
+
+        assertFalse(result.isSuccess());
+        assertEquals("JWT String argument cannot be null or empty.", result.getError());
+    }
+
+    @Test
+    void getAllUserCompanies_userNotFound_returnsFail() {
+        Result<List<ProductionCompanyDTO>> result = userService.getAllUserCompanies(nonExistentUserToken);
+
+        assertFalse(result.isSuccess());
+        assertEquals("User with ID "+NON_EXISTENT_USER_EMAIL+" not found.", result.getError());
+    }
+
+    @Test
+    void getAllUserCompanies_unexpcetedError_returnsFail() {
+        IAuthenticationService faultyAuthService = mock(IAuthenticationService.class);
+        when(faultyAuthService.validateToken(anyString())).thenThrow(new RuntimeException("Database Exploded!!!!!"));
+        UserService faultyUserService = new UserService(faultyAuthService, null, null, null, null, null, null);
+
+        Result<List<ProductionCompanyDTO>> result = faultyUserService.getAllUserCompanies(sessionToken);
+
+        assertFalse(result.isSuccess());
+        assertEquals("An unexpected error occurred: Database Exploded!!!!!", result.getError());
     }
 }

--- a/src/test/java/com/group16b/DomainLayer/Event/EventTests.java
+++ b/src/test/java/com/group16b/DomainLayer/Event/EventTests.java
@@ -241,7 +241,7 @@ public class EventTests {
 			event.activateEvent();
 			LotteryPolicy lotteryPolicy = mock(LotteryPolicy.class);
 			doNothing().when(lotteryPolicy).enrollInLottery(anyInt(), anyString());
-			event.addEventPurchasePolicy(lotteryPolicy);
+			event.setLotteryPolicy(lotteryPolicy);
 			event.enrollInLottery("user1");
 		});
 	}
@@ -253,7 +253,7 @@ public class EventTests {
 					LocalDateTime.parse("2027-10-10T12:00:00"), "Artist", "Category", 1, 0, 0), "0");
 			LotteryPolicy lotteryPolicy = mock(LotteryPolicy.class);
 			doNothing().when(lotteryPolicy).enrollInLottery(anyInt(), anyString());
-			event.addEventPurchasePolicy(lotteryPolicy);
+			event.setLotteryPolicy(lotteryPolicy);
 			event.enrollInLottery("user1");
 		} catch (Exception e) {
 			assertEquals("Can't enroll in lottery for an inactive event", e.getMessage());
@@ -292,7 +292,7 @@ public class EventTests {
 
 		doNothing().when(lotteryPolicy).validateLotteryCode("code123");
 
-		event.addEventPurchasePolicy(lotteryPolicy);
+		event.setLotteryPolicy(lotteryPolicy);
 
 		assertDoesNotThrow(() -> event.validateLotteryCode("code123"));
 		verify(lotteryPolicy, times(1)).validateLotteryCode("code123");
@@ -317,7 +317,7 @@ public class EventTests {
 		doThrow(new IllegalStateException("Invalid lottery code."))
 				.when(lotteryPolicy).validateLotteryCode("badCode");
 
-		event.addEventPurchasePolicy(lotteryPolicy);
+		event.setLotteryPolicy(lotteryPolicy);
 
 		try {
 			event.validateLotteryCode("badCode");
@@ -333,7 +333,7 @@ public class EventTests {
 
 		doNothing().when(lotteryPolicy).renewLotteryCode("code123");
 
-		event.addEventPurchasePolicy(lotteryPolicy);
+		event.setLotteryPolicy(lotteryPolicy);
 
 		assertDoesNotThrow(() -> event.renewLotteryCode("code123"));
 		verify(lotteryPolicy, times(1)).renewLotteryCode("code123");
@@ -354,7 +354,7 @@ public class EventTests {
 		doThrow(new IllegalStateException("Code exploded."))
 				.when(lotteryPolicy).renewLotteryCode("badCode");
 
-		event.addEventPurchasePolicy(lotteryPolicy);
+		event.setLotteryPolicy(lotteryPolicy);
 
 		assertDoesNotThrow(() -> event.renewLotteryCode("badCode"));
 		verify(lotteryPolicy, times(1)).renewLotteryCode("badCode");
@@ -367,7 +367,7 @@ public class EventTests {
 
 		doNothing().when(lotteryPolicy).useCode("code123");
 
-		event.addEventPurchasePolicy(lotteryPolicy);
+		event.setLotteryPolicy(lotteryPolicy);
 
 		assertDoesNotThrow(() -> event.lotteryUseCode("code123"));
 		verify(lotteryPolicy, times(1)).useCode("code123");
@@ -392,7 +392,7 @@ public class EventTests {
 		doThrow(new IllegalStateException("Lottery code already used."))
 				.when(lotteryPolicy).useCode("usedCode");
 
-		event.addEventPurchasePolicy(lotteryPolicy);
+		event.setLotteryPolicy(lotteryPolicy);
 
 		try {
 			event.lotteryUseCode("usedCode");
@@ -413,7 +413,7 @@ public class EventTests {
 		Event event = createValidEvent();
 		LotteryPolicy lotteryPolicy = mock(LotteryPolicy.class);
 
-		event.addEventPurchasePolicy(lotteryPolicy);
+		event.setLotteryPolicy(lotteryPolicy);
 
 		try {
 			event.verifyDoesNotHaveLotteryPolicy();


### PR DESCRIPTION
took out the lottery policy out of purchace policies, and made it a standalone field in all events.
made it so that you can only set the policy once, opposed to the previous implementation where you were allowed to stack them up and only use whoever came first via .stream()
Added the missing tests for get all user companies in user service
fixed the rest of the events