### PR TITLE
451 ticket service

### DIFF
--- a/src/main/java/com/group16b/ApplicationLayer/Exceptions/IllegalTicketInfoException.java
+++ b/src/main/java/com/group16b/ApplicationLayer/Exceptions/IllegalTicketInfoException.java
@@ -1,0 +1,14 @@
+package com.group16b.ApplicationLayer.Exceptions;
+
+public class IllegalTicketInfoException extends RuntimeException {
+    public IllegalTicketInfoException(String msg)
+    {
+        super(msg);
+    }
+
+    public IllegalTicketInfoException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+    
+}

--- a/src/main/java/com/group16b/ApplicationLayer/Exceptions/IssueTicketStatusUnknownException.java
+++ b/src/main/java/com/group16b/ApplicationLayer/Exceptions/IssueTicketStatusUnknownException.java
@@ -1,0 +1,13 @@
+package com.group16b.ApplicationLayer.Exceptions;
+
+public class IssueTicketStatusUnknownException extends RuntimeException{
+    public IssueTicketStatusUnknownException(String msg)
+    {
+        super(msg);
+    }
+
+    public IssueTicketStatusUnknownException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/group16b/ApplicationLayer/Exceptions/RevokeTicketFailureException.java
+++ b/src/main/java/com/group16b/ApplicationLayer/Exceptions/RevokeTicketFailureException.java
@@ -1,0 +1,11 @@
+package com.group16b.ApplicationLayer.Exceptions;
+
+public class RevokeTicketFailureException extends RuntimeException {
+    public RevokeTicketFailureException(String message) {
+        super(message);
+    }
+
+    public RevokeTicketFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/group16b/ApplicationLayer/Exceptions/TicketRevokeUnknownStatusException.java
+++ b/src/main/java/com/group16b/ApplicationLayer/Exceptions/TicketRevokeUnknownStatusException.java
@@ -1,0 +1,12 @@
+package com.group16b.ApplicationLayer.Exceptions;
+
+public class TicketRevokeUnknownStatusException extends RuntimeException {
+    public TicketRevokeUnknownStatusException(String message) {
+        super(message);
+    }
+
+    public TicketRevokeUnknownStatusException(String message, Throwable cause) {
+        super(message, cause);
+    } 
+    
+}

--- a/src/main/java/com/group16b/ApplicationLayer/Interfaces/ITicketGateway.java
+++ b/src/main/java/com/group16b/ApplicationLayer/Interfaces/ITicketGateway.java
@@ -4,4 +4,5 @@ import com.group16b.ApplicationLayer.DTOs.TicketDTO;
 
 public interface ITicketGateway {
     TicketDTO generateTicket(int eventId, String subjectID, String segmentId, String seatId, double price);
+    void revokeTicket(String externalTicketID);
 }

--- a/src/main/java/com/group16b/ApplicationLayer/Interfaces/ITicketGateway.java
+++ b/src/main/java/com/group16b/ApplicationLayer/Interfaces/ITicketGateway.java
@@ -1,8 +1,11 @@
 package com.group16b.ApplicationLayer.Interfaces;
 
-import com.group16b.ApplicationLayer.DTOs.TicketDTO;
+import java.util.List;
 
 public interface ITicketGateway {
-    TicketDTO generateTicket(int eventId, String subjectID, String segmentId, String seatId, double price);
+    //as the name suggests, generate the ticket for the seating segment including the seats
+    String generateSeatingTicket(int eventId, String cusomerId, String zone, List<String> seats);
+    //same but for standing area, includes the quantity
+    String generateGeneralAdmissionTicket(int eventId, String cusomerId, String zone, int quantty);
     void revokeTicket(String externalTicketID);
 }

--- a/src/main/java/com/group16b/ApplicationLayer/OrderService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/OrderService.java
@@ -63,7 +63,7 @@ public class OrderService {
 		this.ticketGateway = ticketGateway;
 	}
 
-    public Result<List<TicketDTO>> CompleteActiveOrder(String orderID, String sTocken, PaymentInfo paymentInfo) {
+    public Result<String> CompleteActiveOrder(String orderID, String sTocken, PaymentInfo paymentInfo) {
 		Integer transactionId = null;
 		try {
 			logger.info("OrderService.CompleteActiveOrder: Attempting to complete order {} ", orderID);
@@ -81,7 +81,6 @@ public class OrderService {
 			logger.info("OrderService.CompleteActiveOrder: verifying that order {} belongs to user {}", orderID, subjectID);
 			order.verifyBelongsToSubject(subjectID);
 
-
 			//3. price calculation
 			logger.info("OrderService.CompleteActiveOrder: calculating price for order {} for user {}", orderID, subjectID);
 			double price = order.getTotalOrderprice();
@@ -91,15 +90,15 @@ public class OrderService {
 			transactionId = paymentService.processPayment(paymentInfo, price); // hander feiler well caouse it will happend regularly
 			
 			// 5. ticket generation
-			logger.info("OrderService.CompleteActiveOrder: generating tickets for order {} for user {}", orderID, subjectID);
-			List<TicketDTO> ticketDTOs = generateTicketsForOrder(order, subjectID, price);
+			logger.info("OrderService.CompleteActiveOrder: generating ticket for order {} for user {}", orderID, subjectID);
+			String ticket = generateTicketForOrder(order, subjectID);
 			
 			// 6. complete order with optimistic locking retry
 			logger.info("OrderService.CompleteActiveOrder: completing order {} for user {} with optimistic locking retry", orderID, subjectID);
 			completeOrderWithOptimisticRetry(orderID, subjectID);
 			
 			// 7. return tickets
-			return Result.makeOk(ticketDTOs);
+			return Result.makeOk(ticket);
 
 		} catch (OrderExpiredException e) {
 			logger.error("OrderService.CompleteActiveOrder: Order {} expired: {}.", orderID, e.getMessage());
@@ -145,28 +144,11 @@ public class OrderService {
 		}
 	}
 
-	private List<TicketDTO> generateTicketsForOrder(Order order, String subjectID, double price) {
-        List<TicketDTO> ticketDTOs = new ArrayList<>();
+	private String generateTicketForOrder(Order order, String subjectID) {
 		if (order.getOrderType() == OrderType.SEAT) {
-			List<String> seats = order.getSeats();
-
-			for (int i = 0; i < order.getNumOfTickets(); i++) {
-					String seatId = null;
-					if (seats != null && i < seats.size()) {
-							seatId = seats.get(i);
-					}
-					TicketDTO ticketDTO = ticketGateway.generateTicket(order.getEventId(), subjectID, order.getSegmentId(), seatId, price);
-
-					ticketDTOs.add(ticketDTO);
-			}
-			return ticketDTOs;
+			return ticketGateway.generateSeatingTicket(order.getEventId(), subjectID, order.getSegmentId(), order.getSeats());
 		}else{
-			for (int i = 0; i < order.getNumOfTickets(); i++) {
-					TicketDTO ticketDTO = ticketGateway.generateTicket(order.getEventId(), subjectID, order.getSegmentId(), null, price);
-
-					ticketDTOs.add(ticketDTO);
-			}
-			return ticketDTOs;
+			return ticketGateway.generateGeneralAdmissionTicket(order.getEventId(), subjectID, order.getSegmentId(), order.getNumOfTickets());
 		}
 	}
 

--- a/src/main/java/com/group16b/ApplicationLayer/OrderService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/OrderService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import com.group16b.ApplicationLayer.DTOs.TicketDTO;
 import com.group16b.ApplicationLayer.Exceptions.AuthException;
+import com.group16b.ApplicationLayer.Exceptions.IssueTicketStatusUnknownException;
 import com.group16b.ApplicationLayer.Exceptions.OrderExpiredException;
 import com.group16b.ApplicationLayer.Exceptions.PaymentFailedException;
 import com.group16b.ApplicationLayer.Exceptions.PaymentStatusUnknownException;
@@ -65,6 +66,7 @@ public class OrderService {
 
     public Result<String> CompleteActiveOrder(String orderID, String sTocken, PaymentInfo paymentInfo) {
 		Integer transactionId = null;
+		String ticket=null;
 		try {
 			logger.info("OrderService.CompleteActiveOrder: Attempting to complete order {} ", orderID);
 
@@ -91,18 +93,18 @@ public class OrderService {
 			
 			// 5. ticket generation
 			logger.info("OrderService.CompleteActiveOrder: generating ticket for order {} for user {}", orderID, subjectID);
-			String ticket = generateTicketForOrder(order, subjectID);
+			ticket = generateTicketForOrder(order, subjectID);
 			
 			// 6. complete order with optimistic locking retry
 			logger.info("OrderService.CompleteActiveOrder: completing order {} for user {} with optimistic locking retry", orderID, subjectID);
-			completeOrderWithOptimisticRetry(orderID, subjectID);
+			completeOrderWithOptimisticRetry(orderID, subjectID,transactionId,ticket);
 			
 			// 7. return tickets
 			return Result.makeOk(ticket);
 
 		} catch (OrderExpiredException e) {
 			logger.error("OrderService.CompleteActiveOrder: Order {} expired: {}.", orderID, e.getMessage());
-			safeRefund(transactionId);
+			safeExternalRollback(transactionId,ticket);
 			_cancelOrder(orderID);
 			return Result.makeFail("Order expired: " + e.getMessage()+". "+POSSIBLE_REFUND_MSG);
 
@@ -112,7 +114,7 @@ public class OrderService {
 
 		} catch (TicketGenerationException e) {
 			logger.error("OrderService.CompleteActiveOrder: Ticket generation failed for order {}: {}", orderID, e.getMessage());
-			safeRefund(transactionId);
+			safeExternalRollback(transactionId,ticket);
 
 			return Result.makeFail("Ticket generation failed: " + e.getMessage()+". "+REFUND_MSG);
 
@@ -129,16 +131,17 @@ public class OrderService {
 			return Result.makeFail("Illegal state: " + e.getMessage());
 
 		} catch (OptimisticLockingFailureException e) {
-			safeRefund(transactionId);
+			safeExternalRollback(transactionId,ticket);
 			return Result.makeFail("Could not complete order due to concurrent update. Please try again. "+POSSIBLE_REFUND_MSG);
-		
 		} catch(PaymentStatusUnknownException e){
 			logger.error("OrderService.CompleteActiveOrder: payment status unknown for order {}. Requires manual reconciliation.",orderID,e);
 			return Result.makeFail("Payment could not be verified. "+POSSIBLE_REFUND_MSG);
-		
+		}catch (IssueTicketStatusUnknownException e){
+			logger.error("OrderService.CompleteActiveOrder: Issue Ticket status unknown for order {}. Requires manual reconciliation.",orderID,e);
+			return Result.makeFail("Ticket could not be verified. "+POSSIBLE_REFUND_MSG);
 		}catch (Exception e) {
 			logger.error("OrderService.CompleteActiveOrder: Unexpected error for order {}: {}", orderID, e.getMessage());
-			safeRefund(transactionId);
+			safeExternalRollback(transactionId,ticket);
 
 			return Result.makeFail("An unexpected error occurred: " + e.getMessage()+". "+POSSIBLE_REFUND_MSG);
 		}
@@ -152,7 +155,7 @@ public class OrderService {
 		}
 	}
 
-	private void completeOrderWithOptimisticRetry(String orderID, String subjectID) {
+	private void completeOrderWithOptimisticRetry(String orderID, String subjectID, int transactionId, String externalTicket) {
 		final int maxRetries = 3;
 
 		for (int attempt = 1; attempt <= maxRetries; attempt++) {
@@ -162,6 +165,8 @@ public class OrderService {
 				freshOrder.validiteOrderIsActive();
 				freshOrder.verifyBelongsToSubject(subjectID);
 
+				freshOrder.setTransactionId(transactionId);
+				freshOrder.setExternalTicket(externalTicket);
 				freshOrder.CompleteOrder();
 				orderRepo.save(freshOrder);
 				return;
@@ -466,6 +471,24 @@ public class OrderService {
 		} catch (Exception e) {
 			logger.error("Refund failed for transaction {}", transactionId, e);
 		}
+	}
+
+	private void safeTicketRevoke(String ticket)
+	{
+		if(ticket==null)
+			return;
+		try{
+			ticketGateway.revokeTicket(ticket);
+		}catch(Exception e)
+		{
+			logger.error("Ticket revoke failed for ticket {}",ticket,e);
+		}
+	}
+
+	private void safeExternalRollback(Integer transactionId, String ticket)
+	{
+		safeRefund(transactionId);
+		safeTicketRevoke(ticket);
 	}
 	
 }

--- a/src/main/java/com/group16b/DomainLayer/Order/Order.java
+++ b/src/main/java/com/group16b/DomainLayer/Order/Order.java
@@ -16,6 +16,9 @@ public class Order {
 	private final String subjectID;
 	private long version;
 
+	private Integer transactioId=null;
+	private String externalTicket=null;
+
 
 	public Order(String segmentId, List<String> seats, double totalPrice, int eventId, String subjectID) {
 		this.orderId = "order_" + ++idCounter;
@@ -90,6 +93,26 @@ public class Order {
 
 	public OrderType getOrderType() {
 		return orderType;
+	}
+
+	public Integer getTransactionId()
+	{
+		return transactioId;
+	}
+
+	public String getExternalTicket()
+	{
+		return externalTicket;
+	}
+
+	public void setTransactionId(int transactionId)
+	{
+		this.transactioId=transactionId;
+	}
+
+	public void setExternalTicket(String ticket)
+	{
+		this.externalTicket=ticket;
 	}
 
 	public void verifyTypeSeats(){

--- a/src/main/java/com/group16b/InfrastructureLayer/ExternalSystems/WsepClient.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/ExternalSystems/WsepClient.java
@@ -55,4 +55,13 @@ public class WsepClient
             throw invalidResponseExceptionFactory.apply(responseBody);
         }
     }
+
+    public void validateBinaryResult(int result,Supplier<RuntimeException> failedExceptionFactory,Supplier<RuntimeException> unknownStatusFactory)
+    {
+        if(result == -1)
+            throw failedExceptionFactory.get();
+
+        if(result != 1)
+            throw unknownStatusFactory.get();
+    }
 }

--- a/src/main/java/com/group16b/InfrastructureLayer/ExternalSystems/WsepClient.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/ExternalSystems/WsepClient.java
@@ -48,14 +48,14 @@ public class WsepClient
             throw emptyResponseExceptionFactory.get();
         }
 
-        return body.trim();
+        return body;
     }
 
     public int parseIntegerResponse(String responseBody,Function<String, RuntimeException> invalidResponseExceptionFactory)
     {
         try
         {
-            return Integer.parseInt(responseBody);
+            return Integer.parseInt(responseBody.trim());
         }
         catch(NumberFormatException e)
         {
@@ -63,7 +63,7 @@ public class WsepClient
         }
     }
 
-    public void validateBinaryResult(int result,Supplier<RuntimeException> failedExceptionFactory,Supplier<RuntimeException> unknownStatusFactory)
+    public void validateSuccessFailureResult(int result,Supplier<RuntimeException> failedExceptionFactory,Supplier<RuntimeException> unknownStatusFactory)
     {
         if(result == -1)
             throw failedExceptionFactory.get();

--- a/src/main/java/com/group16b/InfrastructureLayer/ExternalSystems/WsepClient.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/ExternalSystems/WsepClient.java
@@ -4,8 +4,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -21,8 +24,12 @@ public class WsepClient
         this.restTemplate = restTemplate;
     }
 
-    public String sendRequest(HttpEntity<?> request,Function<RestClientException, RuntimeException> communicationExceptionFactory,Supplier<RuntimeException> emptyResponseExceptionFactory)
+    public String sendRequest(MultiValueMap<String, String> requestBody,Function<RestClientException, RuntimeException> communicationExceptionFactory,Supplier<RuntimeException> emptyResponseExceptionFactory)
     {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request =new HttpEntity<>(requestBody, headers);
         final ResponseEntity<String> response;
 
         try

--- a/src/main/java/com/group16b/InfrastructureLayer/ExternalSystems/WsepClient.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/ExternalSystems/WsepClient.java
@@ -1,0 +1,58 @@
+package com.group16b.InfrastructureLayer.ExternalSystems;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class WsepClient
+{
+    private static final String BASE_URL ="https://damp-lynna-wsep-1984852e.koyeb.app/";
+
+    private final RestTemplate restTemplate;
+
+    public WsepClient(RestTemplate restTemplate)
+    {
+        this.restTemplate = restTemplate;
+    }
+
+    public String sendRequest(HttpEntity<?> request,Function<RestClientException, RuntimeException> communicationExceptionFactory,Supplier<RuntimeException> emptyResponseExceptionFactory)
+    {
+        final ResponseEntity<String> response;
+
+        try
+        {
+            response = restTemplate.postForEntity(BASE_URL,request,String.class);
+        }
+        catch(RestClientException e)
+        {
+            throw communicationExceptionFactory.apply(e);
+        }
+
+        String body = response.getBody();
+
+        if(body == null || body.isBlank())
+        {
+            throw emptyResponseExceptionFactory.get();
+        }
+
+        return body.trim();
+    }
+
+    public int parseIntegerResponse(String responseBody,Function<String, RuntimeException> invalidResponseExceptionFactory)
+    {
+        try
+        {
+            return Integer.parseInt(responseBody);
+        }
+        catch(NumberFormatException e)
+        {
+            throw invalidResponseExceptionFactory.apply(responseBody);
+        }
+    }
+}

--- a/src/main/java/com/group16b/InfrastructureLayer/PaymentService.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/PaymentService.java
@@ -7,6 +7,7 @@ import com.group16b.ApplicationLayer.Exceptions.RefundFailedException;
 import com.group16b.ApplicationLayer.Exceptions.RefundStatusUnknownException;
 import com.group16b.ApplicationLayer.Interfaces.IPaymentGateway;
 import com.group16b.ApplicationLayer.Records.PaymentInfo;
+import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
 
 import java.math.BigDecimal;
 import java.time.YearMonth;
@@ -14,12 +15,9 @@ import java.time.YearMonth;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 @Service
 public class PaymentService implements IPaymentGateway {
@@ -27,12 +25,10 @@ public class PaymentService implements IPaymentGateway {
     private static final int MAX_TRANSACTION_ID=100000;
 
 
-    private static final String BASE_URL="https://damp-lynna-wsep-1984852e.koyeb.app/";
+    private final WsepClient wsepClient;
 
-    private final RestTemplate restTemplate;
-
-    public PaymentService(RestTemplate restTemplate) {
-        this.restTemplate = restTemplate;
+    public PaymentService( WsepClient wsepClient) {
+        this.wsepClient = wsepClient;
     }
 
     //pay, returns the transaction id if successful, or throw on failure
@@ -58,28 +54,12 @@ public class PaymentService implements IPaymentGateway {
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
         
         //send and get the response
-        final ResponseEntity<String> response;
+        String responseBody =wsepClient.sendRequest(requestEntity,
+                e -> new PaymentStatusUnknownException("Failed to contact payment provider", e),
+                () -> new PaymentStatusUnknownException("Payment provider returned empty response")
+            );
 
-        try{
-            response = restTemplate.postForEntity(BASE_URL, requestEntity, String.class);
-        }catch (RestClientException  e){
-            throw new PaymentStatusUnknownException("Failed to contact payment provider", e);
-        }
-
-        String responseBody = response.getBody();
-        if(responseBody == null || responseBody.isBlank()) {
-            throw new PaymentStatusUnknownException("Payment provider returned empty response");
-        }
-
-        final int transactionId;
-        try
-        {
-            transactionId = Integer.parseInt(responseBody.trim());
-        }
-        catch(NumberFormatException e)
-        {
-            throw new PaymentStatusUnknownException("Invalid response from payment provider: " + responseBody,e);
-        }
+        int transactionId =wsepClient.parseIntegerResponse(responseBody,body -> new PaymentStatusUnknownException("Invalid response from payment provider: " + body));
 
         if(transactionId ==-1)
         {
@@ -108,44 +88,16 @@ public class PaymentService implements IPaymentGateway {
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
 
         //send and get the response
-        final ResponseEntity<String> response;
+        String responseBody = wsepClient.sendRequest(requestEntity,  
+            e -> new RefundStatusUnknownException("Failed to contact payment provider during refund for transaction id: "+transactionId, e),
+            () -> new RefundStatusUnknownException("Payment provider returned empty response during refund for transaction id: "+transactionId));
 
-        try
-        {
-            response = restTemplate.postForEntity(BASE_URL, requestEntity, String.class);
-        }
-        catch (RestClientException e)
-        {
-            throw new RefundStatusUnknownException("Failed to contact payment provider during refund: " + transactionId +".", e);
-        }
+        int refundResult = wsepClient.parseIntegerResponse(responseBody,body -> new RefundStatusUnknownException("Invalid response from payment provider during refund id: "+transactionId+", response: " + body));
+        
+        wsepClient.validateBinaryResult(refundResult, 
+            ()->new RefundFailedException("Refund failed for transaction " + transactionId), 
+            ()->new RefundStatusUnknownException("Provider returned invalid refund result: " + refundResult + ", for transaction " + transactionId));
 
-        String responseBody = response.getBody();
-
-        if(responseBody == null || responseBody.isBlank())
-        {
-            throw new RefundStatusUnknownException("Payment provider returned empty refund response for: " + transactionId);
-        }
-
-        final int refundResult;
-
-        try
-        {
-            refundResult = Integer.parseInt(responseBody.trim());
-        }
-        catch(NumberFormatException e)
-        {
-            throw new RefundStatusUnknownException("Invalid refund response from payment provider during refund for: " + transactionId + ", response: " + responseBody, e);
-        }
-
-        if(refundResult == -1)
-        {
-            throw new RefundFailedException("Refund failed for transaction " + transactionId);
-        }
-
-        if(refundResult != 1)
-        {
-            throw new RefundStatusUnknownException("Provider returned invalid refund result: " + refundResult + ", for transaction " + transactionId);
-        }
     }
 
     //can be expanded as needed, like verify number is legit

--- a/src/main/java/com/group16b/InfrastructureLayer/PaymentService.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/PaymentService.java
@@ -81,7 +81,7 @@ public class PaymentService implements IPaymentGateway {
 
         int refundResult = wsepClient.parseIntegerResponse(responseBody,body -> new RefundStatusUnknownException("Invalid response from payment provider during refund id: "+transactionId+", response: " + body));
         
-        wsepClient.validateBinaryResult(refundResult, 
+        wsepClient.validateSuccessFailureResult(refundResult, 
             ()->new RefundFailedException("Refund failed for transaction " + transactionId), 
             ()->new RefundStatusUnknownException("Provider returned invalid refund result: " + refundResult + ", for transaction " + transactionId));
 

--- a/src/main/java/com/group16b/InfrastructureLayer/PaymentService.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/PaymentService.java
@@ -12,9 +12,6 @@ import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
 import java.math.BigDecimal;
 import java.time.YearMonth;
 
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -48,13 +45,8 @@ public class PaymentService implements IPaymentGateway {
         requestBody.add("id", paymentInfo.id());
         requestBody.add("amount", BigDecimal.valueOf(amount).toPlainString());
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
-        
         //send and get the response
-        String responseBody =wsepClient.sendRequest(requestEntity,
+        String responseBody =wsepClient.sendRequest(requestBody,
                 e -> new PaymentStatusUnknownException("Failed to contact payment provider", e),
                 () -> new PaymentStatusUnknownException("Payment provider returned empty response")
             );
@@ -82,13 +74,8 @@ public class PaymentService implements IPaymentGateway {
         requestBody.add("action_type", "refund");
         requestBody.add("transaction_id", String.valueOf(transactionId));
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
-
         //send and get the response
-        String responseBody = wsepClient.sendRequest(requestEntity,  
+        String responseBody = wsepClient.sendRequest(requestBody,  
             e -> new RefundStatusUnknownException("Failed to contact payment provider during refund for transaction id: "+transactionId, e),
             () -> new RefundStatusUnknownException("Payment provider returned empty response during refund for transaction id: "+transactionId));
 

--- a/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
@@ -1,16 +1,13 @@
 package com.group16b.InfrastructureLayer;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.JsonpCharacterEscapes;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.group16b.ApplicationLayer.DTOs.TicketDTO;
 import com.group16b.ApplicationLayer.Exceptions.IllegalTicketInfoException;
 import com.group16b.ApplicationLayer.Exceptions.IssueTicketStatusUnknownException;
 import com.group16b.ApplicationLayer.Exceptions.RevokeTicketFailureException;
@@ -45,8 +42,23 @@ public class TicketGateway implements ITicketGateway{
             throw new IllegalTicketInfoException("Error mapping seats to payload: ",e);
         }
 
+        return issueTicket(requestBody);
+    }
+
+    @Override
+    public String generateGeneralAdmissionTicket(int eventId, String customerId, String zone, int quantity)
+    {
+        validateStandingArgs(eventId, customerId, zone, quantity);
+        MultiValueMap<String, String> requestBody=prepareTicketIssueBody(eventId, customerId, zone);
+        requestBody.add("quantity",String.valueOf(quantity));
+        return issueTicket(requestBody);
+        
+    }
+
+    private String issueTicket(MultiValueMap<String,String> requestBody)
+    {
         String responseBody=wsepClient.sendRequest(requestBody,
-                e-> new IssueTicketStatusUnknownException("Failed to contact ticket provider when issueing ticket."),
+                e-> new IssueTicketStatusUnknownException("Failed to contact ticket provider when issuing ticket."),
                 ()-> new IssueTicketStatusUnknownException("ticket provider returned empty response when issuing ticket."));
         responseBody=responseBody.trim();
         if("-1".equals(responseBody))
@@ -81,18 +93,22 @@ public class TicketGateway implements ITicketGateway{
     {
         if(seats==null || seats.isEmpty())
             throw new IllegalTicketInfoException("For a seating ticket, seats cannot be empty.");
-        validatCommonTicketArgs(eventId, customer, zone);
+        if(seats.stream().anyMatch(s -> s == null || s.isBlank()))
+            throw new IllegalTicketInfoException("For a seating ticket, all seat identifiers must be non-blank.");
+        validateCommonTicketArgs(eventId, customer, zone);
     }
 
     private void validateStandingArgs(int eventId, String customer, String zone, int quantity)
     {
         if(quantity<=0)
-            throw new IllegalTicketInfoException("For a standing ticket, quanty must be positive.");
-        validatCommonTicketArgs(eventId, customer, zone);
+            throw new IllegalTicketInfoException("For a standing ticket, quantity must be positive.");
+        validateCommonTicketArgs(eventId, customer, zone);
     }
 
-    private void validatCommonTicketArgs(int eventId, String customer, String zone)
+    private void validateCommonTicketArgs(int eventId, String customer, String zone)
     {
+        if(eventId <= 0)
+            throw new IllegalTicketInfoException("Event id must be positive.");
         if(customer==null || customer.isBlank())
             throw new IllegalTicketInfoException("Customer id cannot be empty.");
         if(zone==null || zone.isBlank())

--- a/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
@@ -1,16 +1,9 @@
 package com.group16b.InfrastructureLayer;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 import com.group16b.ApplicationLayer.DTOs.TicketDTO;
-import com.group16b.ApplicationLayer.Exceptions.RefundFailedException;
 import com.group16b.ApplicationLayer.Exceptions.RevokeTicketFailureException;
 import com.group16b.ApplicationLayer.Exceptions.TicketGenerationException;
 import com.group16b.ApplicationLayer.Exceptions.TicketRevokeUnknownStatusException;
@@ -19,8 +12,6 @@ import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
 
 @Service
 public class TicketGateway implements ITicketGateway{
-
-    private static final String BASE_URL="https://damp-lynna-wsep-1984852e.koyeb.app/";
 
     private final WsepClient wsepClient;
 

--- a/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
@@ -1,9 +1,18 @@
 package com.group16b.InfrastructureLayer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonpCharacterEscapes;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.group16b.ApplicationLayer.DTOs.TicketDTO;
+import com.group16b.ApplicationLayer.Exceptions.IllegalTicketInfoException;
+import com.group16b.ApplicationLayer.Exceptions.IssueTicketStatusUnknownException;
 import com.group16b.ApplicationLayer.Exceptions.RevokeTicketFailureException;
 import com.group16b.ApplicationLayer.Exceptions.TicketGenerationException;
 import com.group16b.ApplicationLayer.Exceptions.TicketRevokeUnknownStatusException;
@@ -14,6 +23,7 @@ import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
 public class TicketGateway implements ITicketGateway{
 
     private final WsepClient wsepClient;
+    private final ObjectMapper objectMapper=new ObjectMapper();
 
     public TicketGateway(WsepClient wsepClient)
     {
@@ -21,14 +31,28 @@ public class TicketGateway implements ITicketGateway{
     }
 
     @Override
-    public TicketDTO generateTicket(int eventId, String subjectId, String segmentId, String seatId, double price) {
-        if (eventId == -5){ // Simulate a failure in ticket generation for testing purposes
-            throw new TicketGenerationException("Event ID cannot be null");
+    public String generateSeatingTicket(int eventId, String cusomerId, String zone, List<String> seats)
+    {
+        validateSeatingArgs(eventId, cusomerId, zone, seats);
+        MultiValueMap<String, String> requestBody=prepareTicketIssueBody(eventId, cusomerId, zone);
+        requestBody.add("is_seating","true");
+
+        List<Map<String,String>> seatPayload= seats.stream().map( id -> Map.of("seat", id)).toList();
+        try{
+            requestBody.add("seats", objectMapper.writeValueAsString(seatPayload));
         }
-        if(seatId == null) {
-            seatId = "FIELD";
+        catch(JsonProcessingException e){
+            throw new IllegalTicketInfoException("Error mapping seats to payload: ",e);
         }
-        return new TicketDTO(String.valueOf(eventId), subjectId, segmentId, seatId, price);
+
+        String responseBody=wsepClient.sendRequest(requestBody,
+                e-> new IssueTicketStatusUnknownException("Failed to contact ticket provider when issueing ticket."),
+                ()-> new IssueTicketStatusUnknownException("ticket provider returned empty response when issuing ticket."));
+        responseBody=responseBody.trim();
+        if("-1".equals(responseBody))
+            throw new TicketGenerationException("ticket provider refused to issue the ticket");
+
+        return responseBody;
     }
 
     @Override
@@ -49,7 +73,41 @@ public class TicketGateway implements ITicketGateway{
         wsepClient.validateSuccessFailureResult(revokeResult, 
             ()->new RevokeTicketFailureException("revoke failed for ticket: " + externalTicketID),
             ()-> new TicketRevokeUnknownStatusException("Provider returned invalid ticket revoke result: " + revokeResult + ", for ticket: " + externalTicketID));
+    }
 
+
+    //no idea what to validate about eventId so whoever knows the busniess rules add the validation later
+    private void validateSeatingArgs(int eventId, String customer, String zone, List<String> seats)
+    {
+        if(seats==null || seats.isEmpty())
+            throw new IllegalTicketInfoException("For a seating ticket, seats cannot be empty.");
+        validatCommonTicketArgs(eventId, customer, zone);
+    }
+
+    private void validateStandingArgs(int eventId, String customer, String zone, int quantity)
+    {
+        if(quantity<=0)
+            throw new IllegalTicketInfoException("For a standing ticket, quanty must be positive.");
+        validatCommonTicketArgs(eventId, customer, zone);
+    }
+
+    private void validatCommonTicketArgs(int eventId, String customer, String zone)
+    {
+        if(customer==null || customer.isBlank())
+            throw new IllegalTicketInfoException("Customer id cannot be empty.");
+        if(zone==null || zone.isBlank())
+            throw new IllegalTicketInfoException("Zone cannot be empty.");
+    }
+
+    private MultiValueMap<String, String> prepareTicketIssueBody(int eventId, String customer, String zone)
+    {
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("action_type","issue_ticket");
+        requestBody.add("event_id", String.valueOf(eventId));
+        requestBody.add("customer_id", customer);
+        requestBody.add("zone", zone);
+
+        return requestBody;
     }
 
 }

--- a/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
@@ -1,6 +1,7 @@
 package com.group16b.InfrastructureLayer;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import com.group16b.ApplicationLayer.DTOs.TicketDTO;
 import com.group16b.ApplicationLayer.Exceptions.TicketGenerationException;
@@ -8,6 +9,15 @@ import com.group16b.ApplicationLayer.Interfaces.ITicketGateway;
 
 @Service
 public class TicketGateway implements ITicketGateway{
+
+    private static final String BASE_URL="https://damp-lynna-wsep-1984852e.koyeb.app/";
+
+    private final RestTemplate restTemplate;
+
+    public TicketGateway(RestTemplate restTemplate)
+    {
+        this.restTemplate=restTemplate;
+    }
 
     @Override
     public TicketDTO generateTicket(int eventId, String subjectId, String segmentId, String seatId, double price) {
@@ -18,6 +28,12 @@ public class TicketGateway implements ITicketGateway{
             seatId = "FIELD";
         }
         return new TicketDTO(String.valueOf(eventId), subjectId, segmentId, seatId, price);
+    }
+
+    @Override
+    public void revokeTicket(String externalTicketID)
+    {
+
     }
 
 }

--- a/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
@@ -1,10 +1,18 @@
 package com.group16b.InfrastructureLayer;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import com.group16b.ApplicationLayer.DTOs.TicketDTO;
+import com.group16b.ApplicationLayer.Exceptions.RefundFailedException;
 import com.group16b.ApplicationLayer.Exceptions.TicketGenerationException;
+import com.group16b.ApplicationLayer.Exceptions.TicketRevokeUnknownStatusException;
 import com.group16b.ApplicationLayer.Interfaces.ITicketGateway;
 
 @Service
@@ -33,6 +41,50 @@ public class TicketGateway implements ITicketGateway{
     @Override
     public void revokeTicket(String externalTicketID)
     {
+        if(externalTicketID==null || externalTicketID.isBlank())
+            throw new IllegalArgumentException("Ticket cannot be blank.");
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("action_type","cancel_ticket");
+        requestBody.add("ticket_id", externalTicketID);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+        
+        //send and get the response
+        final ResponseEntity<String> response;
+
+        try{
+            response = restTemplate.postForEntity(BASE_URL, requestEntity, String.class);
+        }catch (RestClientException  e){
+            throw new TicketRevokeUnknownStatusException("Failed to contact ticket provider", e);
+        }
+
+        String responseBody = response.getBody();
+        if(responseBody == null || responseBody.isBlank()) {
+            throw new TicketRevokeUnknownStatusException("Payment provider returned empty response");
+        }
+
+        final int revokeResult;
+        try
+        {
+            revokeResult = Integer.parseInt(responseBody.trim());
+        }
+        catch(NumberFormatException e)
+        {
+            throw new TicketRevokeUnknownStatusException("Invalid response from ticket provider: " + responseBody,e);
+        }
+
+        if(revokeResult == -1)
+        {
+            throw new RefundFailedException("revoke failed for ticket: " + externalTicketID);
+        }
+
+        if(revokeResult != 1)
+        {
+            throw new TicketRevokeUnknownStatusException("Provider returned invalid ticket revoke result: " + revokeResult + ", for ticket: " + externalTicketID);
+        }
 
     }
 

--- a/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
@@ -11,20 +11,22 @@ import org.springframework.web.client.RestTemplate;
 
 import com.group16b.ApplicationLayer.DTOs.TicketDTO;
 import com.group16b.ApplicationLayer.Exceptions.RefundFailedException;
+import com.group16b.ApplicationLayer.Exceptions.RevokeTicketFailureException;
 import com.group16b.ApplicationLayer.Exceptions.TicketGenerationException;
 import com.group16b.ApplicationLayer.Exceptions.TicketRevokeUnknownStatusException;
 import com.group16b.ApplicationLayer.Interfaces.ITicketGateway;
+import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
 
 @Service
 public class TicketGateway implements ITicketGateway{
 
     private static final String BASE_URL="https://damp-lynna-wsep-1984852e.koyeb.app/";
 
-    private final RestTemplate restTemplate;
+    private final WsepClient wsepClient;
 
-    public TicketGateway(RestTemplate restTemplate)
+    public TicketGateway(WsepClient wsepClient)
     {
-        this.restTemplate=restTemplate;
+        this.wsepClient=wsepClient;
     }
 
     @Override
@@ -47,44 +49,15 @@ public class TicketGateway implements ITicketGateway{
         requestBody.add("action_type","cancel_ticket");
         requestBody.add("ticket_id", externalTicketID);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        String responseBody=wsepClient.sendRequest(requestBody, 
+                e -> new TicketRevokeUnknownStatusException("Failed to contact ticket provider when revoking ticket: "+externalTicketID, e), 
+                () -> new TicketRevokeUnknownStatusException("ticket provider returned empty response when revoking ticket: "+externalTicketID));
 
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+        final int revokeResult=wsepClient.parseIntegerResponse(responseBody, body -> new TicketRevokeUnknownStatusException("Invalid response from ticket provider: " + body));
         
-        //send and get the response
-        final ResponseEntity<String> response;
-
-        try{
-            response = restTemplate.postForEntity(BASE_URL, requestEntity, String.class);
-        }catch (RestClientException  e){
-            throw new TicketRevokeUnknownStatusException("Failed to contact ticket provider", e);
-        }
-
-        String responseBody = response.getBody();
-        if(responseBody == null || responseBody.isBlank()) {
-            throw new TicketRevokeUnknownStatusException("Payment provider returned empty response");
-        }
-
-        final int revokeResult;
-        try
-        {
-            revokeResult = Integer.parseInt(responseBody.trim());
-        }
-        catch(NumberFormatException e)
-        {
-            throw new TicketRevokeUnknownStatusException("Invalid response from ticket provider: " + responseBody,e);
-        }
-
-        if(revokeResult == -1)
-        {
-            throw new RefundFailedException("revoke failed for ticket: " + externalTicketID);
-        }
-
-        if(revokeResult != 1)
-        {
-            throw new TicketRevokeUnknownStatusException("Provider returned invalid ticket revoke result: " + revokeResult + ", for ticket: " + externalTicketID);
-        }
+        wsepClient.validateSuccessFailureResult(revokeResult, 
+            ()->new RevokeTicketFailureException("revoke failed for ticket: " + externalTicketID),
+            ()-> new TicketRevokeUnknownStatusException("Provider returned invalid ticket revoke result: " + revokeResult + ", for ticket: " + externalTicketID));
 
     }
 

--- a/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/TicketGateway.java
@@ -34,7 +34,7 @@ public class TicketGateway implements ITicketGateway{
         MultiValueMap<String, String> requestBody=prepareTicketIssueBody(eventId, cusomerId, zone);
         requestBody.add("is_seating","true");
 
-        List<Map<String,String>> seatPayload= seats.stream().map( id -> Map.of("seat", id)).toList();
+        List<Map<String,String>> seatPayload =seats.stream().map(this::mapSeat).toList();
         try{
             requestBody.add("seats", objectMapper.writeValueAsString(seatPayload));
         }
@@ -124,6 +124,19 @@ public class TicketGateway implements ITicketGateway{
         requestBody.add("zone", zone);
 
         return requestBody;
+    }
+
+    private Map<String,String> mapSeat(String seatId)
+    {
+        String[] parts = seatId.split("-");
+
+        if(parts.length != 2)
+            throw new IllegalTicketInfoException("Invalid seat id format: " + seatId);
+
+        return Map.of(
+            "row", parts[0],
+            "seat", parts[1]
+        );
     }
 
 }

--- a/src/test/java/com/group16b/ApplicationLayer/OrderServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/OrderServiceTests.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
@@ -89,6 +90,8 @@ public class OrderServiceTests {
         private Order fieldOrder;
 
         private final int TRANSACTION_ID=12345;
+        private final String SEATING_TICKET="amogus";
+        private final String FILED_TIKET="me and my monkey";
         
         @BeforeEach
         void setUp() {
@@ -110,6 +113,7 @@ public class OrderServiceTests {
 
         setUpAuthMocks();
         setUpPaymentMocks();
+        setUpTicketMocks();
 
         orderService = new OrderService(
                 authService,
@@ -192,70 +196,82 @@ public class OrderServiceTests {
         {
                 when(paymentGateway.processPayment(any(), anyInt())).thenReturn(TRANSACTION_ID);
         }
+        private void setUpTicketMocks()
+        {
+                when(ticketGateway.generateGeneralAdmissionTicket(TRANSACTION_ID, anyString(), anyString(), anyInt())).thenReturn(FILED_TIKET);
+                when(ticketGateway.generateSeatingTicket(TRANSACTION_ID, anyString(), anyString(), any())).thenReturn(SEATING_TICKET);
+        }
 
         // _______________CompleteActiveOrder tests:_________________
 
         @Test
         void completeActiveOrder_validSeatOrder_completesOrderGeneratesTicketsAndKeepsReservation() {
-                Result<List<TicketDTO>> result = orderService.CompleteActiveOrder(seatOrder.getOrderId(), "user1", validPaymentInfo());
+                Result<String> result = orderService.CompleteActiveOrder(seatOrder.getOrderId(), "user1", validPaymentInfo());
                 assertTrue(result.isSuccess());
-                assertEquals(2, result.getValue().size());
+                assertEquals(SEATING_TICKET, result.getValue());
                 assertOrderIsCompleted(seatOrder);
 
                 verify(paymentGateway, times(1)).processPayment(any(), eq(100.0));
                 verify(paymentGateway, never()).cancelPayment(anyInt());
-                verify(ticketGateway, times(2)).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 
         @Test
         void completeActiveOrder_validFieldOrder_completesOrderGeneratesTickets() {
-                Result<List<TicketDTO>> result = orderService.CompleteActiveOrder(fieldOrder.getOrderId(), "user1", validPaymentInfo());
+                Result<String> result = orderService.CompleteActiveOrder(fieldOrder.getOrderId(), "user1", validPaymentInfo());
 
                 assertTrue(result.isSuccess());
-                assertEquals(3, result.getValue().size());
+                assertEquals(FILED_TIKET, result.getValue());
                 assertOrderIsCompleted(fieldOrder);
 
                 verify(paymentGateway, times(1)).processPayment(any(), eq(150.0));
                 verify(paymentGateway, never()).cancelPayment(anyInt());
-                verify(ticketGateway, times(3)).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway,times(1)).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 
         @Test
         void completeActiveOrder_invalidToken_failsAndDoesNotChangeOrder() {
-                Result<List<TicketDTO>> result =
-                        orderService.CompleteActiveOrder(seatOrder.getOrderId(), "invalid", validPaymentInfo());
+                Result<String> result =orderService.CompleteActiveOrder(seatOrder.getOrderId(), "invalid", validPaymentInfo());
 
                 assertFalse(result.isSuccess());
                 assertTrue(result.getError().contains("Authentication failed"));
                 assertOrderIsActive(seatOrder);
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
-                verify(ticketGateway, never()).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 
         @Test
         void completeActiveOrder_adminToken_failsAndDoesNotChangeOrder() {
-                Result<List<TicketDTO>> result =
-                        orderService.CompleteActiveOrder(seatOrder.getOrderId(), "admin", validPaymentInfo());
+                Result<String> result =orderService.CompleteActiveOrder(seatOrder.getOrderId(), "admin", validPaymentInfo());
 
                 assertFalse(result.isSuccess());
                 assertTrue(result.getError().contains("Authentication failed"));
                 assertOrderIsActive(seatOrder);
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
-                verify(ticketGateway, never()).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 
         @Test
         void completeActiveOrder_orderNotFound_fails() {
-                Result<List<TicketDTO>> result =
-                        orderService.CompleteActiveOrder("missing-order-id", "user1", validPaymentInfo());
+                Result<String> result =orderService.CompleteActiveOrder("missing-order-id", "user1", validPaymentInfo());
 
                 assertFalse(result.isSuccess());
                 assertTrue(result.getError().contains("Invalid argument"));
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
-                verify(ticketGateway, never()).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 
         @Test
@@ -264,7 +280,7 @@ public class OrderServiceTests {
                         .when(paymentGateway)
                         .processPayment(any(), anyDouble());
 
-                Result<List<TicketDTO>> result =
+                Result<String> result =
                         orderService.CompleteActiveOrder(seatOrder.getOrderId(), "user1", validPaymentInfo());
 
                 assertFalse(result.isSuccess());
@@ -272,15 +288,17 @@ public class OrderServiceTests {
                 assertOrderIsActive(seatOrder);
 
                 verify(paymentGateway, never()).cancelPayment(anyInt());
-                verify(ticketGateway, never()).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 
         @Test
         void completeActiveOrder_ticketGenerationFails_paymentCancelledAndOrderStaysActive() {
-                when(ticketGateway.generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble()))
+                when(ticketGateway.generateSeatingTicket(anyInt(), anyString(), anyString(), any()))
                         .thenThrow(new TicketGenerationException("ticket system failed"));
 
-                Result<List<TicketDTO>> result =
+                Result<String> result =
                         orderService.CompleteActiveOrder(seatOrder.getOrderId(), "user1", validPaymentInfo());
 
                 assertFalse(result.isSuccess());
@@ -288,6 +306,7 @@ public class OrderServiceTests {
                 assertOrderIsActive(seatOrder);
 
                 verify(paymentGateway, times(1)).cancelPayment(anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 //------
         @Test
@@ -302,7 +321,7 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
 
         orderRepo.save(otherUserOrder);
 
-        Result<List<TicketDTO>> result =
+        Result<String> result =
                 orderService.CompleteActiveOrder(otherUserOrder.getOrderId(), "user1", validPaymentInfo());
 
         assertFalse(result.isSuccess());
@@ -310,7 +329,9 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
         assertTrue(orderRepo.findByID(otherUserOrder.getOrderId()).isActive());
 
         verify(paymentGateway, never()).processPayment(any(), anyDouble());
-        verify(ticketGateway, never()).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+        verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+        verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+        verify(ticketGateway,never()).revokeTicket(anyString());
 }
 
         @Test
@@ -319,13 +340,15 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
                 order.CompleteOrder();
                 orderRepo.save(order);
 
-                Result<List<TicketDTO>> result = orderService.CompleteActiveOrder(seatOrder.getOrderId(), "user1", validPaymentInfo());
+                Result<String> result = orderService.CompleteActiveOrder(seatOrder.getOrderId(), "user1", validPaymentInfo());
 
                 assertFalse(result.isSuccess());
                 assertTrue(result.getError().contains("Illegal state"));
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
-                verify(ticketGateway, never()).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 
         @Test
@@ -351,7 +374,7 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
                         ticketGateway
                 );
 
-                Result<List<TicketDTO>> result =
+                Result<String> result =
                         service.CompleteActiveOrder("expired-order", "user1", validPaymentInfo());
 
                 assertFalse(result.isSuccess());
@@ -359,6 +382,9 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
                 verify(paymentGateway, never()).cancelPayment(anyInt());
+                verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
                 verify(mockOrderRepo, times(1)).delete("expired-order");
         }
 
@@ -399,15 +425,15 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
                         ticketGateway
                 );
 
-                Result<List<TicketDTO>> result =
+                Result<String> result =
                         service.CompleteActiveOrder("lock-order", "user1", validPaymentInfo());
 
                 assertTrue(result.isSuccess());
-                assertEquals(2, result.getValue().size());
+                assertEquals(FILED_TIKET, result.getValue());
 
                 verify(paymentGateway, times(1)).processPayment(any(), eq(100.0));
                 verify(paymentGateway, never()).cancelPayment(anyInt());
-                verify(ticketGateway, times(2)).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, times(2)).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt());
                 verify(mockOrderRepo, times(3)).findByID("lock-order");
                 verify(retryOrder1, times(1)).CompleteOrder();
                 verify(retryOrder2, times(1)).CompleteOrder();
@@ -458,7 +484,7 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
                         ticketGateway
                 );
 
-                Result<List<TicketDTO>> result =
+                Result<String> result =
                         service.CompleteActiveOrder("lock-fail-order", "user1", validPaymentInfo());
 
                 assertFalse(result.isSuccess());
@@ -466,71 +492,103 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
 
                 verify(paymentGateway, times(1)).processPayment(any(), eq(100.0));
                 verify(paymentGateway, times(1)).cancelPayment(anyInt());
-                verify(ticketGateway, times(2)).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
+                verify(ticketGateway, times(2)).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt());
                 verify(mockOrderRepo, times(4)).findByID("lock-fail-order");
         }
         
         @Test
-        void completeActiveOrder_twoThreadsSameOrder_onlyOneCompletesSuccessfully() throws Exception {
-                CountDownLatch readyLatch = new CountDownLatch(2);
-                CountDownLatch startLatch = new CountDownLatch(1);
+void completeActiveOrder_twoThreadsSameOrder_onlyOneCompletesSuccessfully() throws Exception {
+    CountDownLatch readyLatch = new CountDownLatch(2);
+    CountDownLatch startLatch = new CountDownLatch(1);
 
-                ExecutorService executor = Executors.newFixedThreadPool(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
 
-                try {
-                        Future<Result<List<TicketDTO>>> firstAttempt = executor.submit(() -> {
-                                readyLatch.countDown();
-                                startLatch.await();
-                                return orderService.CompleteActiveOrder(seatOrder.getOrderId(), "user1", validPaymentInfo());
-                        });
+    try {
+        Future<Result<String>> firstAttempt = executor.submit(() -> {
+            readyLatch.countDown();
+            startLatch.await();
+            return orderService.CompleteActiveOrder(
+                    seatOrder.getOrderId(),
+                    "user1",
+                    validPaymentInfo());
+        });
 
-                        Future<Result<List<TicketDTO>>> secondAttempt = executor.submit(() -> {
-                                readyLatch.countDown();
-                                startLatch.await();
-                                return orderService.CompleteActiveOrder(seatOrder.getOrderId(), "user1", validPaymentInfo());
-                        });
+        Future<Result<String>> secondAttempt = executor.submit(() -> {
+            readyLatch.countDown();
+            startLatch.await();
+            return orderService.CompleteActiveOrder(
+                    seatOrder.getOrderId(),
+                    "user1",
+                    validPaymentInfo());
+        });
 
-                        readyLatch.await();
-                        startLatch.countDown();
+        readyLatch.await();
+        startLatch.countDown();
 
-                        Result<List<TicketDTO>> firstResult = firstAttempt.get();
-                        Result<List<TicketDTO>> secondResult = secondAttempt.get();
+        Result<String> firstResult = firstAttempt.get();
+        Result<String> secondResult = secondAttempt.get();
 
-                        int successCount = 0;
-                        int failureCount = 0;
-                        String failureMessage = "";
-                        if (firstResult.isSuccess()) {
-                                successCount++;
-                        } else {
-                                failureCount++;
-                                failureMessage = firstResult.getError();
-                        }
+        int successCount = 0;
+        int failureCount = 0;
+        String failureMessage = "";
 
-                        if (secondResult.isSuccess()) {
-                                successCount++;
-                        } else {
-                                failureCount++;
-                                failureMessage = secondResult.getError();
-                        }
-
-                        assertEquals(1, successCount);
-                        assertEquals(1, failureCount);
-                        assertOrderIsCompleted(seatOrder);
-                        
-                        verify(paymentGateway, atLeastOnce()).processPayment(any(), eq(100.0));
-                        verify(paymentGateway, atMost(2)).processPayment(any(), eq(100.0));
-                        verify(ticketGateway, atLeast(2)).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
-                        verify(ticketGateway, atMost(4)).generateTicket(anyInt(), anyString(), anyString(), any(), anyDouble());
-                        
-                        if (failureMessage.contains("concurrent update") || failureMessage.contains("Order expired")) {
-                                verify(paymentGateway, times(1)).cancelPayment(TRANSACTION_ID);
-                        } else {
-                                verify(paymentGateway, atMostOnce()).cancelPayment(TRANSACTION_ID);
-                        }
-                } finally {
-                        executor.shutdownNow();
-                }
+        if (firstResult.isSuccess()) {
+            successCount++;
+            assertEquals(SEATING_TICKET, firstResult.getValue());
+        } else {
+            failureCount++;
+            failureMessage = firstResult.getError();
         }
+
+        if (secondResult.isSuccess()) {
+            successCount++;
+            assertEquals(SEATING_TICKET, secondResult.getValue());
+        } else {
+            failureCount++;
+            failureMessage = secondResult.getError();
+        }
+
+        assertEquals(1, successCount);
+        assertEquals(1, failureCount);
+
+        assertOrderIsCompleted(seatOrder);
+
+        verify(paymentGateway, atLeastOnce())
+                .processPayment(any(), eq(100.0));
+
+        verify(paymentGateway, atMost(2))
+                .processPayment(any(), eq(100.0));
+
+        verify(ticketGateway, atLeastOnce())
+                .generateSeatingTicket(
+                        anyInt(),
+                        anyString(),
+                        anyString(),
+                        anyList());
+
+        verify(ticketGateway, atMost(2))
+                .generateSeatingTicket(
+                        anyInt(),
+                        anyString(),
+                        anyString(),
+                        anyList());
+
+        verify(ticketGateway, never())
+                .generateGeneralAdmissionTicket(
+                        anyInt(),
+                        anyString(),
+                        anyString(),
+                        anyInt());
+
+        verify(paymentGateway, atMostOnce())
+                .cancelPayment(TRANSACTION_ID);
+
+        verify(ticketGateway, atMostOnce())
+                .revokeTicket(SEATING_TICKET);
+    } finally {
+        executor.shutdownNow();
+    }
+}
 
         private PaymentInfo validPaymentInfo() {
                 return new PaymentInfo("shekel","12345678910",1,2026,"moshe rabenu","012","215000000");

--- a/src/test/java/com/group16b/ApplicationLayer/OrderServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/OrderServiceTests.java
@@ -198,8 +198,8 @@ public class OrderServiceTests {
         }
         private void setUpTicketMocks()
         {
-                when(ticketGateway.generateGeneralAdmissionTicket(TRANSACTION_ID, anyString(), anyString(), anyInt())).thenReturn(FILED_TIKET);
-                when(ticketGateway.generateSeatingTicket(TRANSACTION_ID, anyString(), anyString(), any())).thenReturn(SEATING_TICKET);
+                when(ticketGateway.generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt())).thenReturn(FILED_TIKET);
+                when(ticketGateway.generateSeatingTicket(anyInt(), anyString(), anyString(), any())).thenReturn(SEATING_TICKET);
         }
 
         // _______________CompleteActiveOrder tests:_________________
@@ -242,7 +242,7 @@ public class OrderServiceTests {
                 assertOrderIsActive(seatOrder);
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
-                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
                 verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
                 verify(ticketGateway,never()).revokeTicket(anyString());
         }
@@ -256,7 +256,7 @@ public class OrderServiceTests {
                 assertOrderIsActive(seatOrder);
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
-                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
                 verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
                 verify(ticketGateway,never()).revokeTicket(anyString());
         }
@@ -269,7 +269,7 @@ public class OrderServiceTests {
                 assertTrue(result.getError().contains("Invalid argument"));
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
-                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
                 verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
                 verify(ticketGateway,never()).revokeTicket(anyString());
         }
@@ -288,7 +288,7 @@ public class OrderServiceTests {
                 assertOrderIsActive(seatOrder);
 
                 verify(paymentGateway, never()).cancelPayment(anyInt());
-                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
                 verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
                 verify(ticketGateway,never()).revokeTicket(anyString());
         }
@@ -329,7 +329,7 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
         assertTrue(orderRepo.findByID(otherUserOrder.getOrderId()).isActive());
 
         verify(paymentGateway, never()).processPayment(any(), anyDouble());
-        verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+        verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
         verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
         verify(ticketGateway,never()).revokeTicket(anyString());
 }
@@ -346,7 +346,7 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
                 assertTrue(result.getError().contains("Illegal state"));
 
                 verify(paymentGateway, never()).processPayment(any(), anyDouble());
-                verify(ticketGateway, times(1)).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
                 verify(ticketGateway,never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(),anyInt());
                 verify(ticketGateway,never()).revokeTicket(anyString());
         }
@@ -433,7 +433,7 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
 
                 verify(paymentGateway, times(1)).processPayment(any(), eq(100.0));
                 verify(paymentGateway, never()).cancelPayment(anyInt());
-                verify(ticketGateway, times(2)).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt());
+                verify(ticketGateway, times(1)).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt());
                 verify(mockOrderRepo, times(3)).findByID("lock-order");
                 verify(retryOrder1, times(1)).CompleteOrder();
                 verify(retryOrder2, times(1)).CompleteOrder();
@@ -492,7 +492,7 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
 
                 verify(paymentGateway, times(1)).processPayment(any(), eq(100.0));
                 verify(paymentGateway, times(1)).cancelPayment(anyInt());
-                verify(ticketGateway, times(2)).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt());
+                verify(ticketGateway, times(1)).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt());
                 verify(mockOrderRepo, times(4)).findByID("lock-fail-order");
         }
         

--- a/src/test/java/com/group16b/ApplicationLayer/OrderServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/OrderServiceTests.java
@@ -34,7 +34,9 @@ import static org.mockito.Mockito.when;
 import org.springframework.dao.OptimisticLockingFailureException;
 
 import com.group16b.ApplicationLayer.DTOs.TicketDTO;
+import com.group16b.ApplicationLayer.Exceptions.IssueTicketStatusUnknownException;
 import com.group16b.ApplicationLayer.Exceptions.PaymentFailedException;
+import com.group16b.ApplicationLayer.Exceptions.PaymentStatusUnknownException;
 import com.group16b.ApplicationLayer.Exceptions.TicketGenerationException;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.ApplicationLayer.Interfaces.IPaymentGateway;
@@ -352,6 +354,51 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
         }
 
         @Test
+        void completeActiveOrder_paymentStatusUnknown_failsWithoutRollback() {
+                doThrow(new PaymentStatusUnknownException("provider timeout")).when(paymentGateway).processPayment(any(), anyDouble());
+
+                Result<String> result =orderService.CompleteActiveOrder(seatOrder.getOrderId(),"user1",validPaymentInfo());
+
+                assertFalse(result.isSuccess());
+                assertTrue(result.getError().contains("Payment could not be verified"));
+
+                assertOrderIsActive(seatOrder);
+
+                verify(paymentGateway, never()).cancelPayment(anyInt());
+                verify(ticketGateway, never()).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+                verify(ticketGateway, never()).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt());
+                verify(ticketGateway, never()).revokeTicket(anyString());
+        }
+
+        @Test
+        void completeActiveOrder_ticketStatusUnknown_failsWithoutRollback() {
+                doThrow(new IssueTicketStatusUnknownException("provider timeout")).when(ticketGateway).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+
+                Result<String> result =orderService.CompleteActiveOrder(seatOrder.getOrderId(),"user1",validPaymentInfo());
+
+                assertFalse(result.isSuccess());
+                assertTrue(result.getError().contains("Ticket could not be verified"));
+
+                assertOrderIsActive(seatOrder);
+
+                verify(paymentGateway, never()).cancelPayment(anyInt());
+                verify(ticketGateway, never()).revokeTicket(anyString());
+        }
+        @Test
+        void completeActiveOrder_ticketGenerationFails_refundFails_stillReturnsFailure() {
+                doThrow(new TicketGenerationException("ticket failed")).when(ticketGateway).generateSeatingTicket(anyInt(), anyString(), anyString(), any());
+
+                doThrow(new RuntimeException("refund failed")).when(paymentGateway).cancelPayment(anyInt());
+
+                Result<String> result =orderService.CompleteActiveOrder(seatOrder.getOrderId(),"user1",validPaymentInfo());
+
+                assertFalse(result.isSuccess());
+                assertTrue(result.getError().contains("Ticket generation failed"));
+
+                verify(paymentGateway).cancelPayment(anyInt());
+        }
+
+        @Test
         void completeActiveOrder_expiredOrder_failsCancelsOrderAndFreesReservation() {
                 Order expiredOrder = mock(Order.class);
 
@@ -437,6 +484,8 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
                 verify(mockOrderRepo, times(3)).findByID("lock-order");
                 verify(retryOrder1, times(1)).CompleteOrder();
                 verify(retryOrder2, times(1)).CompleteOrder();
+                verify(paymentGateway,never()).cancelPayment(anyInt());
+                verify(ticketGateway,never()).revokeTicket(anyString());
         }
 
         @Test
@@ -494,6 +543,7 @@ void completeActiveOrder_orderBelongsToDifferentUser_failsAndDoesNotPay() {
                 verify(paymentGateway, times(1)).cancelPayment(anyInt());
                 verify(ticketGateway, times(1)).generateGeneralAdmissionTicket(anyInt(), anyString(), anyString(), anyInt());
                 verify(mockOrderRepo, times(4)).findByID("lock-fail-order");
+                verify(ticketGateway,times(1)).revokeTicket(anyString());
         }
         
         @Test
@@ -601,6 +651,8 @@ void completeActiveOrder_twoThreadsSameOrder_onlyOneCompletesSuccessfully() thro
         private void assertOrderIsCompleted(Order order) {
                 assertTrue(orderRepo.findByID(order.getOrderId()).isCompleted());
         }
+
+        
 
 
         // _______________ changeSeatsToOrder tests:_________________

--- a/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
 
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
 import com.group16b.ApplicationLayer.DTOs.ProductionCompanyDTO;
@@ -65,7 +66,7 @@ public class UserServiceTests {
         OrderRepositoryMapImpl orderRepo = new OrderRepositoryMapImpl();
         VenueRepositoryMapImpl venueRepo = new VenueRepositoryMapImpl();
         EventRepositoryMapImpl eventRepo = new EventRepositoryMapImpl();
-        TicketGateway ticketGateway = new TicketGateway();
+        TicketGateway ticketGateway = new TicketGateway(mock(RestTemplate.class));
         ProductionCompanyRepositoryMapImpl productionCompanyRepository = new ProductionCompanyRepositoryMapImpl();
 
         userService = new UserService(authService, ticketGateway, venueRepo, userRepo, orderRepo, eventRepo, productionCompanyRepository);

--- a/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
@@ -29,7 +29,8 @@ import com.group16b.InfrastructureLayer.MapDBs.OrderRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.ProductionCompanyRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.UserRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.VenueRepositoryMapImpl;
-import com.group16b.InfrastructureLayer.TicketGateway; 
+import com.group16b.InfrastructureLayer.TicketGateway;
+import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient; 
 
 public class UserServiceTests {
 
@@ -66,7 +67,7 @@ public class UserServiceTests {
         OrderRepositoryMapImpl orderRepo = new OrderRepositoryMapImpl();
         VenueRepositoryMapImpl venueRepo = new VenueRepositoryMapImpl();
         EventRepositoryMapImpl eventRepo = new EventRepositoryMapImpl();
-        TicketGateway ticketGateway = new TicketGateway(mock(RestTemplate.class));
+        TicketGateway ticketGateway = new TicketGateway(new WsepClient(mock(RestTemplate.class)));
         ProductionCompanyRepositoryMapImpl productionCompanyRepository = new ProductionCompanyRepositoryMapImpl();
 
         userService = new UserService(authService, ticketGateway, venueRepo, userRepo, orderRepo, eventRepo, productionCompanyRepository);

--- a/src/test/java/com/group16b/infrastructureLayer/PaymentServiceRealApiTests.java
+++ b/src/test/java/com/group16b/infrastructureLayer/PaymentServiceRealApiTests.java
@@ -11,12 +11,13 @@ import org.springframework.web.client.RestTemplate;
 
 import com.group16b.ApplicationLayer.Records.PaymentInfo;
 import com.group16b.InfrastructureLayer.PaymentService;
+import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
 
 
 @Tag("external")
 class PaymentServiceRealApiTests {
 
-    private PaymentService paymentService=new PaymentService(new RestTemplate());
+    private PaymentService paymentService=new PaymentService(new WsepClient(new RestTemplate()));
 
     private PaymentInfo validPayment() {
         return new PaymentInfo(

--- a/src/test/java/com/group16b/infrastructureLayer/PaymentServiceTests.java
+++ b/src/test/java/com/group16b/infrastructureLayer/PaymentServiceTests.java
@@ -29,6 +29,7 @@ import com.group16b.ApplicationLayer.Exceptions.RefundFailedException;
 import com.group16b.ApplicationLayer.Exceptions.RefundStatusUnknownException;
 import com.group16b.ApplicationLayer.Records.PaymentInfo;
 import com.group16b.InfrastructureLayer.PaymentService;
+import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
 
 
 class PaymentServiceTests{
@@ -61,7 +62,7 @@ class PaymentServiceTests{
     void setup()
     {
         restTemplate=mock(RestTemplate.class);
-        paymentService=new PaymentService(restTemplate);
+        paymentService=new PaymentService(new WsepClient(restTemplate));
         ResponseEntity<String> response =new ResponseEntity<>(TRANSACTION_ID_STRING, HttpStatus.OK);
 
         when(restTemplate.postForEntity(anyString(),any(HttpEntity.class),eq(String.class))).thenReturn(response);
@@ -396,7 +397,7 @@ class PaymentServiceTests{
 
         var ex = assertThrows(RefundStatusUnknownException.class,() -> paymentService.cancelPayment(TRANSACTION_ID));
 
-        assertEquals("Failed to contact payment provider during refund: "+ TRANSACTION_ID + ".",ex.getMessage());
+        assertEquals("Failed to contact payment provider during refund for transaction id: "+ TRANSACTION_ID,ex.getMessage());
     }
 
     @Test
@@ -406,7 +407,7 @@ class PaymentServiceTests{
 
         var ex = assertThrows(RefundStatusUnknownException.class,() -> paymentService.cancelPayment(TRANSACTION_ID));
 
-        assertEquals("Payment provider returned empty refund response for: "+ TRANSACTION_ID,ex.getMessage());
+        assertEquals("Payment provider returned empty response during refund for transaction id: "+ TRANSACTION_ID,ex.getMessage());
     }
 
     @Test
@@ -416,7 +417,7 @@ class PaymentServiceTests{
 
         var ex = assertThrows(RefundStatusUnknownException.class,() -> paymentService.cancelPayment(TRANSACTION_ID));
 
-        assertEquals("Payment provider returned empty refund response for: " + TRANSACTION_ID,ex.getMessage());
+        assertEquals("Payment provider returned empty response during refund for transaction id: " + TRANSACTION_ID,ex.getMessage());
     }
 
     @Test
@@ -426,7 +427,7 @@ class PaymentServiceTests{
 
         var ex = assertThrows(RefundStatusUnknownException.class,() -> paymentService.cancelPayment(TRANSACTION_ID));
 
-        assertEquals("Invalid refund response from payment provider during refund for: " + TRANSACTION_ID + ", response: abc",ex.getMessage());
+        assertEquals("Invalid response from payment provider during refund id: " + TRANSACTION_ID + ", response: abc",ex.getMessage());
     }
 
     @Test

--- a/src/test/java/com/group16b/infrastructureLayer/TicketGatewayRealApiTests.java
+++ b/src/test/java/com/group16b/infrastructureLayer/TicketGatewayRealApiTests.java
@@ -1,0 +1,69 @@
+package com.group16b.infrastructureLayer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
+
+import com.group16b.InfrastructureLayer.TicketGateway;
+import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
+
+@Tag("external")
+class TicketGatewayRealApiTests {
+
+    private final TicketGateway ticketGateway =
+            new TicketGateway(new WsepClient(new RestTemplate()));
+
+    @Test
+    void generateSeatingTicket_returnsTicketId() {
+        String ticketId = ticketGateway.generateSeatingTicket(
+                123,
+                "smoke-test-user",
+                "A",
+                List.of("1", "2"));
+
+        assertNotNull(ticketId);
+        assertFalse(ticketId.isBlank());
+    }
+
+    @Test
+    void generateGeneralAdmissionTicket_returnsTicketId() {
+        String ticketId = ticketGateway.generateGeneralAdmissionTicket(
+                123,
+                "smoke-test-user",
+                "A",
+                2);
+
+        assertNotNull(ticketId);
+        assertFalse(ticketId.isBlank());
+    }
+
+    @Test
+    void seatingTicket_canBeIssuedAndRevoked() {
+        String ticketId = ticketGateway.generateSeatingTicket(
+                123,
+                "smoke-test-user",
+                "A",
+                List.of("A-1", "A-2"));
+
+        assertDoesNotThrow(() ->
+                ticketGateway.revokeTicket(ticketId));
+    }
+
+    @Test
+    void generalAdmissionTicket_canBeIssuedAndRevoked() {
+        String ticketId = ticketGateway.generateGeneralAdmissionTicket(
+                123,
+                "smoke-test-user",
+                "A",
+                2);
+
+        assertDoesNotThrow(() ->
+                ticketGateway.revokeTicket(ticketId));
+    }
+}

--- a/src/test/java/com/group16b/infrastructureLayer/TicketGatewayRealApiTests.java
+++ b/src/test/java/com/group16b/infrastructureLayer/TicketGatewayRealApiTests.java
@@ -25,7 +25,7 @@ class TicketGatewayRealApiTests {
                 123,
                 "smoke-test-user",
                 "A",
-                List.of("1", "2"));
+                List.of("A-1", "A-2"));
 
         assertNotNull(ticketId);
         assertFalse(ticketId.isBlank());

--- a/src/test/java/com/group16b/infrastructureLayer/TicketGatewayTests.java
+++ b/src/test/java/com/group16b/infrastructureLayer/TicketGatewayTests.java
@@ -26,7 +26,9 @@ import org.springframework.web.client.RestTemplate;
 
 import com.group16b.ApplicationLayer.Exceptions.IllegalTicketInfoException;
 import com.group16b.ApplicationLayer.Exceptions.IssueTicketStatusUnknownException;
+import com.group16b.ApplicationLayer.Exceptions.RevokeTicketFailureException;
 import com.group16b.ApplicationLayer.Exceptions.TicketGenerationException;
+import com.group16b.ApplicationLayer.Exceptions.TicketRevokeUnknownStatusException;
 import com.group16b.InfrastructureLayer.TicketGateway;
 import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
 
@@ -152,7 +154,7 @@ public class TicketGatewayTests {
     }
 
     @Test
-    void seatingTicket_restClientException_throwsIssueTicketUnknownStatus() {
+    void IssueTicket_restClientException_throwsIssueTicketUnknownStatus() {
         mockCommunicationFailure();
 
         IssueTicketStatusUnknownException ex = assertThrows(IssueTicketStatusUnknownException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,VALID_SEATS));
@@ -164,14 +166,92 @@ public class TicketGatewayTests {
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"", " ", "    "})
-    void seatingTicket_nullOrBlankResponse_throwsIssueTicketUnknownStatus(String responseBody) {
+    void IssueTicket_nullOrBlankResponse_throwsIssueTicketUnknownStatus(String responseBody) {
         when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
                 .thenReturn(new ResponseEntity<>(responseBody, HttpStatus.OK));
 
-        RuntimeException ex = assertThrows(RuntimeException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,VALID_SEATS));
-
-        assertTrue(ex.getClass().getSimpleName().contains("IssueTicketStatusUnknownException"),"Expected IssueTicketStatusUnknownException but got: " + ex.getClass().getName());
+        IssueTicketStatusUnknownException ex = assertThrows(IssueTicketStatusUnknownException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,VALID_SEATS));
+        assertEquals("ticket provider returned empty response when issuing ticket.", ex.getMessage());
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0,-1,-100})
+    void standingTicket_invalidQuantity_throwsIllegalTicketInfoException(int num) {
+        IllegalTicketInfoException ex = assertThrows(IllegalTicketInfoException.class,() -> ticketGateway.generateGeneralAdmissionTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,num));
+
+        assertEquals("For a standing ticket, quantity must be positive.", ex.getMessage());
+    }
+
+    //--------------- REVOKE YOUR BELIEFS ---------------------
+
+    @Test
+    void revokeTicket_goodTicket_yay()
+    {
+        assertDoesNotThrow(()->ticketGateway.revokeTicket(TICKET));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void revokeTicket_givenBlankTicket_throwIllegaArg(String sasuke)
+    {
+        IllegalArgumentException ex=assertThrows(IllegalArgumentException.class, ()->ticketGateway.revokeTicket(sasuke));
+        assertEquals("Ticket cannot be blank.", ex.getMessage());
+    }
+
+    @Test
+    void revokeTicket_restClientException_throwsIssueTicketUnknownStatus() {
+        mockCommunicationFailure();
+
+        TicketRevokeUnknownStatusException ex = assertThrows(TicketRevokeUnknownStatusException.class,() -> ticketGateway.revokeTicket(TICKET));
+
+        assertEquals("Failed to contact ticket provider when revoking ticket: "+TICKET, ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"", " ", "    "})
+    void revokeTicket_nullOrBlankResponse_throwsIssueTicketUnknownStatus(String responseBody) {
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(responseBody, HttpStatus.OK));
+
+        TicketRevokeUnknownStatusException ex = assertThrows(TicketRevokeUnknownStatusException.class,() -> ticketGateway.revokeTicket(TICKET));
+        assertEquals("ticket provider returned empty response when revoking ticket: "+TICKET, ex.getMessage());
+    }
+
+    @Test
+    void revokeTicket_resultMinusOne_throwsRevokeFailureException() {
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<>("-1", HttpStatus.OK));
+
+        RevokeTicketFailureException ex = assertThrows(RevokeTicketFailureException.class,() -> ticketGateway.revokeTicket(TICKET));
+
+        assertTrue(ex.getMessage().contains("revoke failed for ticket"));
+    }
+
+    @Test
+    void revokeTicket_invalidNumberResponse_throwsUnknownStatus() {
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<>("not-a-number", HttpStatus.OK));
+
+        TicketRevokeUnknownStatusException ex = assertThrows(TicketRevokeUnknownStatusException.class,() -> ticketGateway.revokeTicket(TICKET));
+
+        assertTrue(ex.getMessage().contains("Invalid response from ticket provider"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 2, 999, -2})
+    void revokeTicket_nonStandardResult_throwsUnknownStatus(int result) {
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(String.valueOf(result), HttpStatus.OK));
+
+        TicketRevokeUnknownStatusException ex = assertThrows(TicketRevokeUnknownStatusException.class,() -> ticketGateway.revokeTicket(TICKET));
+
+        assertTrue(ex.getMessage().contains("invalid ticket revoke result"));
+    }
+
+
+
 
 
     

--- a/src/test/java/com/group16b/infrastructureLayer/TicketGatewayTests.java
+++ b/src/test/java/com/group16b/infrastructureLayer/TicketGatewayTests.java
@@ -1,0 +1,181 @@
+package com.group16b.infrastructureLayer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.group16b.ApplicationLayer.Exceptions.IllegalTicketInfoException;
+import com.group16b.ApplicationLayer.Exceptions.IssueTicketStatusUnknownException;
+import com.group16b.ApplicationLayer.Exceptions.TicketGenerationException;
+import com.group16b.InfrastructureLayer.TicketGateway;
+import com.group16b.InfrastructureLayer.ExternalSystems.WsepClient;
+
+public class TicketGatewayTests {
+    private TicketGateway ticketGateway;
+    private RestTemplate restTemplate;
+
+    private final int VALID_EVENT_ID = 1;
+    private final String VALID_CUSTOMER = "perry the platipus";
+    private final String VALID_ZONE = "A";
+    private List<String> VALID_SEATS;
+    private final String INVALID_SEAT="hamburger.com";
+    private final int VALID_QUANTITY = 2;
+
+    private final String TICKET="ratatui is real and he is coming after you";
+
+    @BeforeEach
+    void setup()
+    {
+        restTemplate=mock(RestTemplate.class);
+        ticketGateway=new TicketGateway(new WsepClient(restTemplate));
+        VALID_SEATS = List.of("1-1","1-42");
+
+        when(restTemplate.postForEntity(
+        anyString(),
+        any(HttpEntity.class),
+        eq(String.class))).thenAnswer(invocation -> {
+            HttpEntity<?> entity = invocation.getArgument(1);
+
+            @SuppressWarnings("unchecked")
+            MultiValueMap<String, String> body =(MultiValueMap<String, String>) entity.getBody();
+
+            String action = body.getFirst("action_type");
+
+            if ("issue_ticket".equals(action)) {
+                return new ResponseEntity<>(TICKET, HttpStatus.OK);
+            }
+
+            if ("cancel_ticket".equals(action)) {
+                return new ResponseEntity<>("1", HttpStatus.OK);
+            }
+
+            throw new IllegalStateException("Unexpected action: " + action);
+        });
+        
+    }
+    private List<String> validSeatsPlus(String seat) {
+        List<String> seats = new ArrayList<>(VALID_SEATS);
+        seats.add(seat);
+        return seats;
+    }
+
+    private void mockCommunicationFailure() {
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new org.springframework.web.client.RestClientException("connection failed"));
+    }
+
+    @Test
+    void givenValidTicketData_whenReturnedValidTicket_thenReturnCorrectTicket() {
+        String ticketId = ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,VALID_SEATS);
+
+        assertEquals(TICKET, ticketId);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void seatingTicket_emptySeatList_throwsIllegalTicketInfoException(List<String> seats) {
+        IllegalTicketInfoException ex = assertThrows(IllegalTicketInfoException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,seats));
+
+        assertEquals("For a seating ticket, seats cannot be empty.", ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void seatingTicket_emptySeat_throwsIllegalTicketInfoException(String seat) {
+        List<String> seats = validSeatsPlus(seat);
+        IllegalTicketInfoException ex = assertThrows(IllegalTicketInfoException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,seats));
+
+        assertEquals("For a seating ticket, all seat identifiers must be non-blank.", ex.getMessage());
+    }
+
+    @Test
+    void seatingTicket_IllegalSeatFormat_throwsIllegalTicketInfoException() {
+        List<String> seats = validSeatsPlus(INVALID_SEAT);
+        IllegalTicketInfoException ex = assertThrows(IllegalTicketInfoException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,seats));
+
+        assertEquals("Invalid seat id format: "+INVALID_SEAT, ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0,-1,-100})
+    void seatingTicket_invalidEventId_throwsIllegalTicketInfoException(int id) {
+        IllegalTicketInfoException ex = assertThrows(IllegalTicketInfoException.class,() -> ticketGateway.generateSeatingTicket(id,VALID_CUSTOMER,VALID_ZONE,VALID_SEATS));
+
+        assertEquals("Event id must be positive.", ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "  "})
+    void seatingTicket_blankUserId_throwsIllegalTicketInfoException(String moshe) {
+        IllegalTicketInfoException ex = assertThrows(IllegalTicketInfoException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,moshe,VALID_ZONE,VALID_SEATS));
+
+        assertEquals("Customer id cannot be empty.", ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "  "})
+    void seatingTicket_blankZone_throwsIllegalTicketInfoException(String zamzheno) {
+        IllegalTicketInfoException ex = assertThrows(IllegalTicketInfoException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,zamzheno,VALID_SEATS));
+
+        assertEquals("Zone cannot be empty.", ex.getMessage());
+    }
+
+    @Test
+    void IssueTicket_ticketIssueRefused_throwException()
+    {
+        when(restTemplate.postForEntity(anyString(),any(HttpEntity.class),eq(String.class))).thenReturn(new ResponseEntity<>("-1", HttpStatus.OK));
+        TicketGenerationException ex = assertThrows(TicketGenerationException.class,() -> ticketGateway.generateSeatingTicket( VALID_EVENT_ID, VALID_CUSTOMER, VALID_ZONE, VALID_SEATS));
+
+        assertEquals("ticket provider refused to issue the ticket", ex.getMessage());
+    }
+
+    @Test
+    void seatingTicket_restClientException_throwsIssueTicketUnknownStatus() {
+        mockCommunicationFailure();
+
+        IssueTicketStatusUnknownException ex = assertThrows(IssueTicketStatusUnknownException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,VALID_SEATS));
+
+        assertEquals("Failed to contact ticket provider when issuing ticket.", ex.getMessage());
+    }
+
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"", " ", "    "})
+    void seatingTicket_nullOrBlankResponse_throwsIssueTicketUnknownStatus(String responseBody) {
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(responseBody, HttpStatus.OK));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,() -> ticketGateway.generateSeatingTicket(VALID_EVENT_ID,VALID_CUSTOMER,VALID_ZONE,VALID_SEATS));
+
+        assertTrue(ex.getClass().getSimpleName().contains("IssueTicketStatusUnknownException"),"Expected IssueTicketStatusUnknownException but got: " + ex.getClass().getName());
+    }
+
+
+    
+
+
+    
+}


### PR DESCRIPTION
implemented the proper ticket service that communicates with the external api
turned ticket to simply be a string, and now a completed order saves both the ticket and the transaction id, i dont know the status of the refactor of order db so maybe they will need to add it
added a general WSEP client that is responsible for talking to the external api, our services use it
added tests, fixed tests, fixed service, then more tests
added more exceptions, hopefully didnt forget anything