### PR TITLE
503 get permissions

### DIFF
--- a/src/main/java/com/group16b/ApiLayer/CompanyHierarchyController.java
+++ b/src/main/java/com/group16b/ApiLayer/CompanyHierarchyController.java
@@ -96,4 +96,10 @@ public class CompanyHierarchyController extends BaseController {
         return executeWithReturnData(() -> companyHierarchyService.hierarchyTree(companyId, authToken));
     }
 
+    @GetMapping("/me/permissions")
+    public ResponseEntity<?> getCompanyPerms(@PathVariable("companyId") int companyId)
+    {
+        return executeWithReturnData(() -> companyHierarchyService.getComapanyPermissions(companyId));
+    }
+
 }

--- a/src/main/java/com/group16b/ApiLayer/ProductionCompanyController.java
+++ b/src/main/java/com/group16b/ApiLayer/ProductionCompanyController.java
@@ -60,5 +60,11 @@ public class ProductionCompanyController extends BaseController {
     {
         return executeWithReturnData(() -> productionCompanyService.getCompanyAllEvents(companyId));
     }
+
+    @GetMapping("/{companyId}/permissions")
+    public ResponseEntity<?> getCompanyPerms(@PathVariable("companyId") int companyId)
+    {
+        return executeWithReturnData(() -> productionCompanyService.getCompanyAllEvents(companyId));
+    }
     
 }

--- a/src/main/java/com/group16b/ApiLayer/ProductionCompanyController.java
+++ b/src/main/java/com/group16b/ApiLayer/ProductionCompanyController.java
@@ -60,11 +60,5 @@ public class ProductionCompanyController extends BaseController {
     {
         return executeWithReturnData(() -> productionCompanyService.getCompanyAllEvents(companyId));
     }
-
-    @GetMapping("/{companyId}/permissions")
-    public ResponseEntity<?> getCompanyPerms(@PathVariable("companyId") int companyId)
-    {
-        return executeWithReturnData(() -> productionCompanyService.getCompanyAllEvents(companyId));
-    }
     
 }

--- a/src/main/java/com/group16b/ApiLayer/UserController.java
+++ b/src/main/java/com/group16b/ApiLayer/UserController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.group16b.ApplicationLayer.DTOs.LoginRequestDTO;
 import com.group16b.ApplicationLayer.UserService;
 import com.group16b.InfrastructureLayer.Security.PublicEndpoint;
+import com.group16b.InfrastructureLayer.Security.Role;
 
 @RestController
 @RequestMapping("/api/user")
@@ -48,15 +49,15 @@ public class UserController extends BaseController {
     
     @GetMapping("/role/admin")
     public ResponseEntity<?> isAdmin(@RequestHeader("Authorization") String sessionToken) {
-        return executeWithReturnData(() -> userService.isRole(sessionToken,"Admin"));
+        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.ADMIN.value()));
     }
     @GetMapping("/role/signed")
     public ResponseEntity<?> isSigned(@RequestHeader("Authorization") String sessionToken) {
-        return executeWithReturnData(() -> userService.isRole(sessionToken,"Signed"));
+        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.SIGNED.value()));
     }
     @GetMapping("/role/guest")
     public ResponseEntity<?> isAGuest(@RequestHeader("Authorization") String sessionToken) {
-        return executeWithReturnData(() -> userService.isRole(sessionToken,"Guest"));
+        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.GUEST.value()));
     }
     @GetMapping("/me/active-order")
     public ResponseEntity<?> getUserActiveOrder(@RequestHeader("Authorization") String sessionToken) {

--- a/src/main/java/com/group16b/ApiLayer/UserController.java
+++ b/src/main/java/com/group16b/ApiLayer/UserController.java
@@ -49,15 +49,15 @@ public class UserController extends BaseController {
     
     @GetMapping("/role/admin")
     public ResponseEntity<?> isAdmin(@RequestHeader("Authorization") String sessionToken) {
-        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.ADMIN.value()));
+        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.ADMIN));
     }
     @GetMapping("/role/signed")
     public ResponseEntity<?> isSigned(@RequestHeader("Authorization") String sessionToken) {
-        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.SIGNED.value()));
+        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.SIGNED));
     }
     @GetMapping("/role/guest")
     public ResponseEntity<?> isAGuest(@RequestHeader("Authorization") String sessionToken) {
-        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.GUEST.value()));
+        return executeWithReturnData(() -> userService.isRole(sessionToken,Role.GUEST));
     }
     @GetMapping("/me/active-order")
     public ResponseEntity<?> getUserActiveOrder(@RequestHeader("Authorization") String sessionToken) {

--- a/src/main/java/com/group16b/ApplicationLayer/CompanyHierarchyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/CompanyHierarchyService.java
@@ -18,6 +18,8 @@ import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.ProductionCompany.membership.HierarchyNodeData;
 import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
 import com.group16b.DomainLayer.User.User;
+import com.group16b.InfrastructureLayer.RequestContext;
+import com.group16b.InfrastructureLayer.Security.Role;
 
 import io.jsonwebtoken.JwtException;
 
@@ -463,6 +465,29 @@ public class CompanyHierarchyService {
 		}
 	}
 
+	    public Result<Set<ManagerPermissions>> getComapanyPermissions(int companyID)
+    {
+        try{
+            logger.info("ProductionCompanService.getComapanyPermissions: retrieving permissions");
+            
+            String userId=validateRoleAndGetUserId();
+            ProductionCompany company=productionCompanyRepository.findByID(String.valueOf(companyID));
+            
+            logger.info("ProductionCompanService.getComapanyPermissions: succesfully retrieved permissions for user {} in company {}",userId,companyID);
+            return Result.makeOk(company.getUserPermissions(userId));
+
+        } catch(AuthException e){
+            logger.warn("ProductionCompanService.getComapanyPermissions: AuthException: {}",e.getMessage());
+            return Result.makeFail(e.getMessage());
+        } catch (IllegalArgumentException e){
+            logger.warn("ProductionCompanService.getComapanyPermissions: IllegalArgumentException: {}",e.getMessage());
+            return Result.makeFail(e.getMessage());
+        } catch (Exception e){
+            logger.error("ProductionCompanService.getComapanyPermissions: Unexpected Exception: ",e);
+            return Result.makeFail("An unexpected error occured, pls try again later");
+        }
+    }
+
 	private String validateAndGetUserID(String sessionToken) {
 		if (!authenticationService.validateToken(sessionToken)) {
 			throw new AuthException("Invalid Token");
@@ -475,5 +500,14 @@ public class CompanyHierarchyService {
 		userRepository.findByID(userID);
 		return userID;
 	}
+
+	private String validateRoleAndGetUserId()
+    {
+        //if we do implement error 403 then this if will also disapear, along with the function
+        if(!Role.SIGNED.equals(RequestContext.getRole()))
+            throw new AuthException("Only users are allowed to perform this operation.");
+        String userId=RequestContext.getUserId();
+        return userId;
+    }
 
 }

--- a/src/main/java/com/group16b/ApplicationLayer/CompanyHierarchyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/CompanyHierarchyService.java
@@ -465,26 +465,26 @@ public class CompanyHierarchyService {
 		}
 	}
 
-	    public Result<Set<ManagerPermissions>> getComapanyPermissions(int companyID)
+	public Result<Set<ManagerPermissions>> getComapanyPermissions(int companyID)
     {
         try{
-            logger.info("ProductionCompanService.getComapanyPermissions: retrieving permissions");
+            logger.info("companyHierarchyService.getComapanyPermissions: retrieving permissions");
             
             String userId=validateRoleAndGetUserId();
             ProductionCompany company=productionCompanyRepository.findByID(String.valueOf(companyID));
             
-            logger.info("ProductionCompanService.getComapanyPermissions: succesfully retrieved permissions for user {} in company {}",userId,companyID);
+            logger.info("companyHierarchyService.getComapanyPermissions: succesfully retrieved permissions for user {} in company {}",userId,companyID);
             return Result.makeOk(company.getUserPermissions(userId));
 
         } catch(AuthException e){
-            logger.warn("ProductionCompanService.getComapanyPermissions: AuthException: {}",e.getMessage());
+            logger.warn("companyHierarchyService.getComapanyPermissions: AuthException: {}",e.getMessage());
             return Result.makeFail(e.getMessage());
         } catch (IllegalArgumentException e){
-            logger.warn("ProductionCompanService.getComapanyPermissions: IllegalArgumentException: {}",e.getMessage());
+            logger.warn("companyHierarchyService.getComapanyPermissions: IllegalArgumentException: {}",e.getMessage());
             return Result.makeFail(e.getMessage());
         } catch (Exception e){
-            logger.error("ProductionCompanService.getComapanyPermissions: Unexpected Exception: ",e);
-            return Result.makeFail("An unexpected error occured, pls try again later");
+            logger.error("companyHierarchyService.getComapanyPermissions: Unexpected Exception: ",e);
+            return Result.makeFail("An unexpected error occured, pls try again later.");
         }
     }
 
@@ -506,8 +506,8 @@ public class CompanyHierarchyService {
         //if we do implement error 403 then this if will also disapear, along with the function
         if(!Role.SIGNED.equals(RequestContext.getRole()))
             throw new AuthException("Only users are allowed to perform this operation.");
-        String userId=RequestContext.getUserId();
-        return userId;
+
+        return RequestContext.getUserId();
     }
 
 }

--- a/src/main/java/com/group16b/ApplicationLayer/DTOs/ProductionCompanyInfoDTO.java
+++ b/src/main/java/com/group16b/ApplicationLayer/DTOs/ProductionCompanyInfoDTO.java
@@ -1,0 +1,28 @@
+package com.group16b.ApplicationLayer.DTOs;
+
+import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
+
+public class ProductionCompanyInfoDTO {
+        private int id;
+    private double rating;
+    private String name;
+
+
+    public ProductionCompanyInfoDTO(ProductionCompany company) {
+        this.id = company.getProductionCompanyID();
+        this.name = company.getName();
+        this.rating = company.getRating();
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public double getRating() {
+        return rating;
+    }
+}

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -24,7 +24,9 @@ import com.group16b.DomainLayer.ProductionCompany.IProductionCompanyRepository;
 import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
 import com.group16b.DomainLayer.User.User;
+import com.group16b.InfrastructureLayer.RequestContext;
 import com.group16b.InfrastructureLayer.IdGenerators.ProductionCompanyIdGen;
+import com.group16b.InfrastructureLayer.Security.Role;
 
 @Service
 public class ProductionCompanyService {
@@ -195,6 +197,29 @@ public class ProductionCompanyService {
         }
     }
 
+    public Result<Set<ManagerPermissions>> getComapanyPermissions(int companyID)
+    {
+        try{
+            logger.info("ProductionCompanService.getComapanyPermissions: retrieving permissions");
+            
+            String userId=validateRoleAndGetUserId();
+            ProductionCompany company=productionRepo.findByID(String.valueOf(companyID));
+            
+            logger.info("ProductionCompanService.getComapanyPermissions: succesfully retrieved permissions for user {} in company {}",userId,companyID);
+            return Result.makeOk(company.getUserPermissions(userId));
+
+        } catch(AuthException e){
+            logger.warn("ProductionCompanService.getComapanyPermissions: AuthException: {}",e.getMessage());
+            return Result.makeFail(e.getMessage());
+        } catch (IllegalArgumentException e){
+            logger.warn("ProductionCompanService.getComapanyPermissions: IllegalArgumentException: {}",e.getMessage());
+            return Result.makeFail(e.getMessage());
+        } catch (Exception e){
+            logger.error("ProductionCompanService.getComapanyPermissions: Unexpected Exception: ",e);
+            return Result.makeFail("An unexpected error occured, pls try again later");
+        }
+    }
+
     // gets all orders for the company
     private Set<Integer> getCompanyEventIDs(int companyID) {
         return getCompanyEvents(companyID).stream()
@@ -261,6 +286,15 @@ public class ProductionCompanyService {
         // verify user exists in the database, i.e not a stale user
         userRepo.findByID(userID);
         return userID;
+    }
+
+    private String validateRoleAndGetUserId()
+    {
+        //if we do implement error 403 then this if will also disapear, along with the function
+        if(!Role.SIGNED.equals(RequestContext.getRole()))
+            throw new AuthException("Only users are allowed to perform this operation.");
+        String userId=RequestContext.getUserId();
+        return userId;
     }
 
 }

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -197,28 +197,6 @@ public class ProductionCompanyService {
         }
     }
 
-    public Result<Set<ManagerPermissions>> getComapanyPermissions(int companyID)
-    {
-        try{
-            logger.info("ProductionCompanService.getComapanyPermissions: retrieving permissions");
-            
-            String userId=validateRoleAndGetUserId();
-            ProductionCompany company=productionRepo.findByID(String.valueOf(companyID));
-            
-            logger.info("ProductionCompanService.getComapanyPermissions: succesfully retrieved permissions for user {} in company {}",userId,companyID);
-            return Result.makeOk(company.getUserPermissions(userId));
-
-        } catch(AuthException e){
-            logger.warn("ProductionCompanService.getComapanyPermissions: AuthException: {}",e.getMessage());
-            return Result.makeFail(e.getMessage());
-        } catch (IllegalArgumentException e){
-            logger.warn("ProductionCompanService.getComapanyPermissions: IllegalArgumentException: {}",e.getMessage());
-            return Result.makeFail(e.getMessage());
-        } catch (Exception e){
-            logger.error("ProductionCompanService.getComapanyPermissions: Unexpected Exception: ",e);
-            return Result.makeFail("An unexpected error occured, pls try again later");
-        }
-    }
 
     // gets all orders for the company
     private Set<Integer> getCompanyEventIDs(int companyID) {

--- a/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/ProductionCompanyService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import com.group16b.ApplicationLayer.DTOs.EventDTO;
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
 import com.group16b.ApplicationLayer.DTOs.ProductionCompanyDTO;
+import com.group16b.ApplicationLayer.DTOs.ProductionCompanyInfoDTO;
 import com.group16b.ApplicationLayer.Exceptions.AuthException;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.ApplicationLayer.Objects.Result;
@@ -153,7 +154,7 @@ public class ProductionCompanyService {
         }
     }
 
-    public Result<ProductionCompanyDTO> getProductionCompany(int companyID) {
+    public Result<ProductionCompanyInfoDTO> getProductionCompany(int companyID) {
         try {
             logger.info("ProductionCompanyService.getProductionCompany: Retrieving production company with id {}",
                     companyID);
@@ -161,7 +162,7 @@ public class ProductionCompanyService {
             logger.info(
                     "ProductionCompanyService.getProductionCompany: Successfully retrieved production company with id {}",
                     companyID);
-            return Result.makeOk(new ProductionCompanyDTO(company));
+            return Result.makeOk(new ProductionCompanyInfoDTO(company));
         } catch (IllegalArgumentException e) {
             logger.warn("ProductionCompanyService.getProductionCompany: IllegalArgumentException: " + e.getMessage());
             return Result.makeFail(e.getMessage());

--- a/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
+++ b/src/main/java/com/group16b/DomainLayer/ProductionCompany/ProductionCompany.java
@@ -304,6 +304,14 @@ public class ProductionCompany {
         return result;
     }
 
+    public Set<ManagerPermissions> getUserPermissions(String userID)
+    {
+        MembershipNode node=membersNodes.get(userID);
+        if(node==null)
+            throw new IllegalArgumentException("User "+userID+" is not part of the company.");
+        return node.getPermissions();
+    }
+
     public void validateUserPermissions(String userID, RoleType type)
     {
         MembershipNode node=membersNodes.get(userID);

--- a/src/main/java/com/group16b/InfrastructureLayer/AuthenticationServiceJWTImpl.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/AuthenticationServiceJWTImpl.java
@@ -59,15 +59,15 @@ public class AuthenticationServiceJWTImpl implements IAuthenticationService {
     }
 
     public String generateVisitor_GuestToken(SessionToken session) {
-        return createToken(session.getValue(), Role.GUEST.value(), userExpirationTime, userKey);
+        return createToken(session.getValue(), Role.GUEST, userExpirationTime, userKey);
     }
 
     public String generateVisitor_SignedToken(String userID) {
-        return createToken(userID, Role.SIGNED.value(), userExpirationTime, userKey);
+        return createToken(userID, Role.SIGNED, userExpirationTime, userKey);
     }
 
     public String generateAdminToken(String adminID) {
-        return createToken(String.valueOf(adminID), Role.ADMIN.value(), adminExpirationTime, adminKey);
+        return createToken(String.valueOf(adminID), Role.ADMIN, adminExpirationTime, adminKey);
     }
 
     @Override
@@ -93,7 +93,7 @@ public class AuthenticationServiceJWTImpl implements IAuthenticationService {
     @Override
     public boolean isUserToken(String token) {
         try {
-            return this.extractRoleFromToken(token).equals(Role.SIGNED.value());
+            return this.extractRoleFromToken(token).equals(Role.SIGNED);
         } catch (Exception e) {
             return false;
         }
@@ -102,7 +102,7 @@ public class AuthenticationServiceJWTImpl implements IAuthenticationService {
     @Override
     public boolean isGuestToken(String token) {
         try {
-            return this.extractRoleFromToken(token).equals(Role.GUEST.value());
+            return this.extractRoleFromToken(token).equals(Role.GUEST);
         } catch (Exception e) {
             return false;
         }
@@ -111,7 +111,7 @@ public class AuthenticationServiceJWTImpl implements IAuthenticationService {
     @Override
     public boolean isAdminToken(String token) {
         try {
-            return this.extractRoleFromToken(token).equals(Role.ADMIN.value());
+            return this.extractRoleFromToken(token).equals(Role.ADMIN);
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/group16b/InfrastructureLayer/AuthenticationServiceJWTImpl.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/AuthenticationServiceJWTImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.DomainLayer.User.SessionToken;
+import com.group16b.InfrastructureLayer.Security.Role;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -58,15 +59,15 @@ public class AuthenticationServiceJWTImpl implements IAuthenticationService {
     }
 
     public String generateVisitor_GuestToken(SessionToken session) {
-        return createToken(session.getValue(), "Guest", userExpirationTime, userKey);
+        return createToken(session.getValue(), Role.GUEST.value(), userExpirationTime, userKey);
     }
 
     public String generateVisitor_SignedToken(String userID) {
-        return createToken(userID, "Signed", userExpirationTime, userKey);
+        return createToken(userID, Role.SIGNED.value(), userExpirationTime, userKey);
     }
 
     public String generateAdminToken(String adminID) {
-        return createToken(String.valueOf(adminID), "Admin", adminExpirationTime, adminKey);
+        return createToken(String.valueOf(adminID), Role.ADMIN.value(), adminExpirationTime, adminKey);
     }
 
     @Override
@@ -92,7 +93,7 @@ public class AuthenticationServiceJWTImpl implements IAuthenticationService {
     @Override
     public boolean isUserToken(String token) {
         try {
-            return this.extractRoleFromToken(token).equals("Signed");
+            return this.extractRoleFromToken(token).equals(Role.SIGNED.value());
         } catch (Exception e) {
             return false;
         }
@@ -101,7 +102,7 @@ public class AuthenticationServiceJWTImpl implements IAuthenticationService {
     @Override
     public boolean isGuestToken(String token) {
         try {
-            return this.extractRoleFromToken(token).equals("Guest");
+            return this.extractRoleFromToken(token).equals(Role.GUEST.value());
         } catch (Exception e) {
             return false;
         }
@@ -110,7 +111,7 @@ public class AuthenticationServiceJWTImpl implements IAuthenticationService {
     @Override
     public boolean isAdminToken(String token) {
         try {
-            return this.extractRoleFromToken(token).equals("Admin");
+            return this.extractRoleFromToken(token).equals(Role.ADMIN.value());
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/group16b/InfrastructureLayer/RequestContext.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/RequestContext.java
@@ -1,5 +1,6 @@
 package com.group16b.InfrastructureLayer;
 
+
 public class RequestContext {
 
     private static final ThreadLocal<String> userIdHolder = new ThreadLocal<>();

--- a/src/main/java/com/group16b/InfrastructureLayer/Security/Role.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Security/Role.java
@@ -1,0 +1,17 @@
+package com.group16b.InfrastructureLayer.Security;
+
+public enum Role {
+    SIGNED("Signed"),
+    ADMIN("Admin"),
+    GUEST("Guest");
+
+    private final String displayName;
+
+    Role(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String value() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/group16b/InfrastructureLayer/Security/Role.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Security/Role.java
@@ -1,17 +1,7 @@
 package com.group16b.InfrastructureLayer.Security;
 
-public enum Role {
-    SIGNED("Signed"),
-    ADMIN("Admin"),
-    GUEST("Guest");
-
-    private final String displayName;
-
-    Role(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String value() {
-        return displayName;
-    }
+public class Role {
+   public static final String SIGNED="SIGNED";
+   public static final String ADMIN="Admin";
+   public static final String GUEST="Guest";
 }

--- a/src/test/java/com/group16b/ApplicationLayer/CompanyHierarchyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/CompanyHierarchyServiceTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,8 +33,10 @@ import com.group16b.DomainLayer.ProductionCompany.IProductionCompanyRepository;
 import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.ProductionCompany.membership.ManagerPermissions;
 import com.group16b.DomainLayer.User.User;
+import com.group16b.InfrastructureLayer.RequestContext;
 import com.group16b.InfrastructureLayer.MapDBs.ProductionCompanyRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.UserRepositoryMapImpl;
+import com.group16b.InfrastructureLayer.Security.Role;
 
 public class CompanyHierarchyServiceTests {
         private CompanyHierarchyService CompanyHierarchyService;
@@ -2835,6 +2838,55 @@ public class CompanyHierarchyServiceTests {
         }
 
 
+        @Test
+        void getCompanyPerms_ValidUser_getPerms()
+        {
+                RequestContext.set(MANAGER2_EMAIL,Role.SIGNED);
+                Result<Set<ManagerPermissions>> result=CompanyHierarchyService.getComapanyPermissions(COMPANY1_ID);
+                assertTrue(result.isSuccess());
+                assertEquals(ALL_MANAGER_PERMISSIONS, result.getValue());
+        }
+
+        @Test
+        void getCompanyPerms_NotUserToken_AuthException()
+        {
+                RequestContext.set(MANAGER2_EMAIL,Role.ADMIN);
+                Result<Set<ManagerPermissions>> result=CompanyHierarchyService.getComapanyPermissions(COMPANY1_ID);
+                assertFalse(result.isSuccess());
+                assertEquals("Only users are allowed to perform this operation.", result.getError());
+        }
+
+        @Test
+        void getCompanyPerms_NotMemberOfCompany_IllegalArg()
+        {
+                RequestContext.set(BYSTANDER_EMAIL,Role.SIGNED);
+                Result<Set<ManagerPermissions>> result=CompanyHierarchyService.getComapanyPermissions(COMPANY1_ID);
+                assertFalse(result.isSuccess());
+                assertEquals("User "+BYSTANDER_EMAIL+" is not part of the company.", result.getError());
+        }
+
+        @Test
+        void getCompanyPerms_CompanyNotFound_IllegalArg()
+        {
+                RequestContext.set(MANAGER1_EMAIL,Role.SIGNED);
+                Result<Set<ManagerPermissions>> result=CompanyHierarchyService.getComapanyPermissions(BAD_COMPANY_ID);
+                assertFalse(result.isSuccess());
+                assertEquals("Production company with ID "+BAD_COMPANY_ID+" is not found.", result.getError());
+        }
+
+        @Test
+        void getCompanyPerms_UnexpectedERROR_catch()
+        {
+                RequestContext.set(MANAGER1_EMAIL,Role.SIGNED);
+                IProductionCompanyRepository mockRepo=mock(IProductionCompanyRepository.class);
+                CompanyHierarchyService=new CompanyHierarchyService(mockAuthService, mockRepo, UserRepository);
+                
+                doThrow(new RuntimeException("The zombies are coming")).when(mockRepo).findByID(anyString());
+                Result<Set<ManagerPermissions>> result=CompanyHierarchyService.getComapanyPermissions(BAD_COMPANY_ID);
+                assertFalse(result.isSuccess());
+                assertEquals("An unexpected error occured, pls try again later.", result.getError());
+        }
+        
 
 
 

--- a/src/test/java/com/group16b/ApplicationLayer/EventServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/EventServiceTests.java
@@ -41,6 +41,7 @@ import com.group16b.InfrastructureLayer.MapDBs.ProductionCompanyRepositoryMapImp
 import com.group16b.InfrastructureLayer.MapDBs.UserRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.VenueRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.VirtualQueueRepositoryMapImpl;
+import com.group16b.InfrastructureLayer.Security.Role;
 
 public class EventServiceTests {
 
@@ -81,13 +82,13 @@ public class EventServiceTests {
 
                 user1 = new User("testuser1", "password");
                 when(mockTokenService.validateToken("user1")).thenReturn(true);
-                when(mockTokenService.extractRoleFromToken("user1")).thenReturn("Signed");
+                when(mockTokenService.extractRoleFromToken("user1")).thenReturn(Role.SIGNED);
                 when(mockTokenService.isUserToken("user1")).thenReturn(true);
                 when(mockTokenService.extractSubjectFromToken("user1")).thenReturn(String.valueOf(user1.getEmail()));
 
                 user2 = new User("testuser2", "password");
                 when(mockTokenService.validateToken("user2")).thenReturn(true);
-                when(mockTokenService.extractRoleFromToken("user2")).thenReturn("Signed");
+                when(mockTokenService.extractRoleFromToken("user2")).thenReturn(Role.SIGNED);
                 when(mockTokenService.isUserToken("user2")).thenReturn(true);
                 when(mockTokenService.extractSubjectFromToken("user2")).thenReturn(String.valueOf(user2.getEmail()));
 

--- a/src/test/java/com/group16b/ApplicationLayer/PurchasePolicyServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/PurchasePolicyServiceTests.java
@@ -45,6 +45,7 @@ import com.group16b.InfrastructureLayer.MapDBs.ProductionCompanyRepositoryMapImp
 import com.group16b.InfrastructureLayer.MapDBs.UserRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.VenueRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.VirtualQueueRepositoryMapImpl;
+import com.group16b.InfrastructureLayer.Security.Role;
 import com.group16b.DomainLayer.Policies.PurchasePolicy.MinTicketsPolicy;
 
 public class PurchasePolicyServiceTests {
@@ -84,14 +85,14 @@ public class PurchasePolicyServiceTests {
         user = new User("testuser", "password");
         userRepository.save(user);
         when(mockTokenService.validateToken("user1")).thenReturn(true);
-        when(mockTokenService.extractRoleFromToken("user1")).thenReturn("Signed");
+        when(mockTokenService.extractRoleFromToken("user1")).thenReturn(Role.SIGNED);
         when(mockTokenService.isUserToken("user1")).thenReturn(true);
         when(mockTokenService.extractSubjectFromToken("user1")).thenReturn(String.valueOf(user.getEmail()));
 
         user2 = new User("testuser2", "password");
         userRepository.save(user2);
         when(mockTokenService.validateToken("user2")).thenReturn(true);
-        when(mockTokenService.extractRoleFromToken("user2")).thenReturn("Signed");
+        when(mockTokenService.extractRoleFromToken("user2")).thenReturn(Role.SIGNED);
         when(mockTokenService.isUserToken("user2")).thenReturn(true);
         when(mockTokenService.extractSubjectFromToken("user2")).thenReturn(String.valueOf(user2.getEmail()));
 

--- a/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/UserServiceTests.java
@@ -31,6 +31,7 @@ import com.group16b.InfrastructureLayer.MapDBs.OrderRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.ProductionCompanyRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.UserRepositoryMapImpl;
 import com.group16b.InfrastructureLayer.MapDBs.VenueRepositoryMapImpl;
+import com.group16b.InfrastructureLayer.Security.Role;
 import com.group16b.InfrastructureLayer.TicketGateway; 
 
 public class UserServiceTests {
@@ -54,10 +55,6 @@ public class UserServiceTests {
     private final String OTHER_USER_EMAIL = "noorders@test.com";
     private final String NO_COMPANY_USER_EMAIL = "no-comps@wa.com";
     private final String NON_EXISTENT_USER_EMAIL = "birds are fake";
-
-    private final String ADMIN_ROLE="Admin";
-    private final String GUEST_ROLE="Guest";
-    private final String USER_ROLE="Signed";
 
 @BeforeEach
     void setUp() {
@@ -334,35 +331,35 @@ public class UserServiceTests {
     @Test
     void isRoleAdmin_adminToken_returnTrue()
     {
-        Result<Boolean> result = userService.isRole(adminToken, ADMIN_ROLE);
+        Result<Boolean> result = userService.isRole(adminToken, Role.ADMIN);
         assertTrue(result.isSuccess());
         assertEquals(true, result.getValue());
     }
     @Test
-    void isRoleUser_adminToken_returnTrue()
+    void isRoleUser_UserToken_returnTrue()
     {
-        Result<Boolean> result = userService.isRole(sessionToken, USER_ROLE);
+        Result<Boolean> result = userService.isRole(sessionToken, Role.SIGNED);
         assertTrue(result.isSuccess());
         assertEquals(true, result.getValue());
     }
     @Test
-    void isRoleGuest_adminToken_returnTrue()
+    void isRoleGuest_GuestToken_returnTrue()
     {
-        Result<Boolean> result = userService.isRole(guestToken, GUEST_ROLE);
+        Result<Boolean> result = userService.isRole(guestToken, Role.GUEST);
         assertTrue(result.isSuccess());
         assertEquals(true, result.getValue());
     }
     @Test
     void isRole_InvalidRole_returnFalse()
     {
-        Result<Boolean> result = userService.isRole(guestToken, ADMIN_ROLE);
+        Result<Boolean> result = userService.isRole(guestToken, Role.ADMIN);
         assertTrue(result.isSuccess());
         assertEquals(false, result.getValue());
     }
     @Test
     void isRole_BadToekn_returnError()
     {
-        Result<Boolean> result = userService.isRole("chi-vap-chi-chi", GUEST_ROLE);
+        Result<Boolean> result = userService.isRole("chi-vap-chi-chi", Role.GUEST);
         assertFalse(result.isSuccess());
         assertEquals("Invalid Token", result.getError());
     }
@@ -372,7 +369,7 @@ public class UserServiceTests {
         IAuthenticationService mockAuthenticationService=mock(IAuthenticationService.class);
         doThrow(new RuntimeException("I recognize the bodies in the water...")).when(mockAuthenticationService).validateToken(anyString());
         userService=new UserService(mockAuthenticationService, null, null, userRepo, null, null, null);
-        Result<Boolean> result = userService.isRole(guestToken, GUEST_ROLE);
+        Result<Boolean> result = userService.isRole(guestToken, Role.GUEST);
         assertFalse(result.isSuccess());
         assertEquals("An unexpected error occured, pls try again later.", result.getError());
     }

--- a/src/test/java/com/group16b/ApplicationLayer/VenueEventConfigServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/VenueEventConfigServiceTests.java
@@ -46,6 +46,7 @@ import com.group16b.DomainLayer.Venue.Location;
 import com.group16b.DomainLayer.Venue.Stage;
 import com.group16b.DomainLayer.Venue.Venue;
 import com.group16b.DomainLayer.Venue.VenueGrid;
+import com.group16b.InfrastructureLayer.Security.Role;
 
 public class VenueEventConfigServiceTests {
 
@@ -124,7 +125,7 @@ public class VenueEventConfigServiceTests {
                 VenueRecord validRecord = createValidVenueRecord();
 
                 when(mockAuthService.validateToken(validToken)).thenReturn(true);
-                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn("User");
+                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn(Role.SIGNED);
                 when(mockAuthService.isUserToken(validToken)).thenReturn(true);
                 when(mockAuthService.isUserToken(validToken)).thenReturn(true);
                 when(mockAuthService.extractSubjectFromToken(validToken)).thenReturn(userIDString);
@@ -159,7 +160,7 @@ public class VenueEventConfigServiceTests {
                 VenueRecord validRecord = createValidVenueRecord();
 
                 when(mockAuthService.validateToken(validToken)).thenReturn(true);
-                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn("User");
+                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn(Role.SIGNED);
                 when(mockAuthService.isUserToken(validToken)).thenReturn(true);
                 when(mockAuthService.extractSubjectFromToken(validToken)).thenReturn(userIDString);
 
@@ -199,7 +200,7 @@ public class VenueEventConfigServiceTests {
         void configureNewLayoutAndInventory_TokenRoleIsNotUser_ReturnsFailResult() {
                 VenueRecord validRecord = createValidVenueRecord();
                 when(mockAuthService.validateToken(validToken)).thenReturn(true);
-                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn("Admin"); // Wrong role
+                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn(Role.SIGNED); // Wrong role
 
                 Result<String> result = configService.configureNewLayoutAndInventory(
                                 validToken, companyID, validRecord);
@@ -217,7 +218,7 @@ public class VenueEventConfigServiceTests {
                 VenueRecord validRecord = createValidVenueRecord();
 
                 when(mockAuthService.validateToken(validToken)).thenReturn(true);
-                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn("User");
+                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn(Role.SIGNED);
                 when(mockAuthService.isUserToken(validToken)).thenReturn(true);
                 when(mockAuthService.extractSubjectFromToken(validToken)).thenReturn(userIDString);
 
@@ -245,7 +246,7 @@ public class VenueEventConfigServiceTests {
                 VenueRecord validRecord = createValidVenueRecord();
 
                 when(mockAuthService.validateToken(validToken)).thenReturn(true);
-                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn("User");
+                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn(Role.SIGNED);
                 when(mockAuthService.isUserToken(validToken)).thenReturn(true);
                 when(mockAuthService.extractSubjectFromToken(validToken)).thenReturn(userIDString);
 
@@ -276,7 +277,7 @@ public class VenueEventConfigServiceTests {
         void configureNewLayoutAndInventory_EventDoesNotExist_ReturnsFailResult() {
                 VenueRecord validRecord = createValidVenueRecord();
                 when(mockAuthService.validateToken(validToken)).thenReturn(true);
-                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn("User");
+                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn(Role.SIGNED);
                 when(mockAuthService.isUserToken(validToken)).thenReturn(true);
                 when(mockAuthService.extractSubjectFromToken(validToken)).thenReturn(userIDString);
                 when(mockEventRepository.findByID(String.valueOf(eventID)))
@@ -292,7 +293,7 @@ public class VenueEventConfigServiceTests {
         void configureNewLayoutAndInventory_GenericSystemException_ReturnsFailResult() {
                 VenueRecord validRecord = createValidVenueRecord();
                 when(mockAuthService.validateToken(validToken)).thenReturn(true);
-                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn("User");
+                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn(Role.SIGNED);
                 when(mockAuthService.isUserToken(validToken)).thenReturn(true);
 
                 when(mockAuthService.extractSubjectFromToken(validToken)).thenReturn("invalid_id_format");
@@ -307,7 +308,7 @@ public class VenueEventConfigServiceTests {
         @Test
         void configureNewLayoutAndInventory_NullVenueLayout_TriggersSystemException_ReturnsFailResult() {
                 when(mockAuthService.validateToken(validToken)).thenReturn(true);
-                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn("User");
+                when(mockAuthService.extractRoleFromToken(validToken)).thenReturn(Role.SIGNED);
                 when(mockAuthService.isUserToken(validToken)).thenReturn(true);
                 when(mockAuthService.extractSubjectFromToken(validToken)).thenReturn(userIDString);
 

--- a/src/test/java/com/group16b/infrastructureLayer/Security/AuthInterceptorTests.java
+++ b/src/test/java/com/group16b/infrastructureLayer/Security/AuthInterceptorTests.java
@@ -23,6 +23,7 @@ import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.InfrastructureLayer.RequestContext;
 import com.group16b.InfrastructureLayer.Security.AuthInterceptor;
 import com.group16b.InfrastructureLayer.Security.PublicEndpoint;
+import com.group16b.InfrastructureLayer.Security.Role;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -48,7 +49,7 @@ public class AuthInterceptorTests {
     private final String BAD_TOKEN="I PLAY POKMON GO EVERYDAY";
 
     private final String GOOD_SUBJECT="Gordon ramzy";
-    private final String AVARAGE_ROLE="Signed";
+    private final String AVARAGE_ROLE=Role.SIGNED;
     private final String OLD="your mama";
 
     @BeforeEach


### PR DESCRIPTION
added get perms to companyHierarchy
made it that get company only returns name, id and rating(not that for create company and the admin version of get companies, they still return the full company including founder id and the tree)
added tests
made the Roles to be constants, as to avoid typos and magic values, and replaced the strings with them in the auth impl, the IsRole entry, and some other places