### PR TITLE
554 delete user bug

### DIFF
--- a/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
@@ -1,4 +1,6 @@
 package com.group16b.ApplicationLayer;
+import java.time.LocalDateTime;
+import java.time.chrono.ChronoLocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -261,9 +263,10 @@ public class AdminManagementService {
     {
          logger.info("AdminManagementService.deactivateEventAndRefundUser: Deactivating event {}", eventID);
          try{
+            Event event=null;
             while(true){
                 try{
-                    Event event=eventRepo.findByID(String.valueOf(eventID));
+                    event=eventRepo.findByID(String.valueOf(eventID));
                     event.deactivateEvent();
                     eventRepo.save(event);
                     break;
@@ -281,7 +284,11 @@ public class AdminManagementService {
             }
 
             logger.info("AdminManagementService.deactivateEventAndRefundUser: Deactivated event {}", eventID);
-            
+            if(!event.getEventStartTime().isAfter(LocalDateTime.now()))
+            {
+                logger.info("AdminManagementService.deactivateEventAndRefundUser: event {} has already passed, no need for refunds", eventID);
+                return;
+            }
             List<Order> orders=orderRepo.getByEventId(eventID);
             List<RefundResult> refundResults=new ArrayList<>();
             int successCount=0, failCount=0;

--- a/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
@@ -1,4 +1,5 @@
 package com.group16b.ApplicationLayer;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -278,16 +279,29 @@ public class AdminManagementService {
             }
 
             logger.info("AdminManagementService.deactivateEventAndRefundUser: Deactivated event {}", eventID);
+            
             List<Order> orders=orderRepo.getByEventId(eventID);
+            List<RefundResult> refundResults=new ArrayList<>();
+            int successCount=0, failCount=0;
             for(Order order : orders)
             {
-                if(cancelOrder(order.getOrderId()))
-                    refundOrder(order.getOrderId());
+                if(cancelOrder(order.getOrderId())){
+                    RefundResult res=refundOrder(order.getOrderId());
+                    if(res.status()==RefundStatus.SUCCESS)
+                        successCount++;
+                    else
+                        failCount++;
+                    refundResults.add(res);
+                }
             }
+
+            logger.info("AdminManagementService.deactivateEventAndRefundUser: finished refunding, successes: {}, failures: {}.",successCount,failCount);
+            if(failCount!=0)
+                logger.warn("AdminManagementService.deactivateEventAndRefundUser: SOME REFUNDS FAILED FOR EVENT {}, manuall reconsaliation is needed! Also don't forget to brushyour teeth!",eventID);
 
 
          } catch(Exception e){
-            
+            logger.error("AdminManagementService.deactivateEventAndRefundUser: An unexpected exception: ",e);
          }
     }
 

--- a/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
@@ -12,6 +12,8 @@ import com.group16b.ApplicationLayer.DTOs.ProductionCompanyDTO;
 import com.group16b.ApplicationLayer.DTOs.UserDTO;
 import com.group16b.ApplicationLayer.Exceptions.AuthException;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
+import com.group16b.ApplicationLayer.Interfaces.IPaymentGateway;
+import com.group16b.ApplicationLayer.Interfaces.ITicketGateway;
 import com.group16b.ApplicationLayer.Objects.Result;
 import com.group16b.DomainLayer.Event.Event;
 import com.group16b.DomainLayer.Event.IEventRepository;
@@ -33,14 +35,18 @@ public class AdminManagementService {
     private final IEventRepository eventRepo;
 	private final IAuthenticationService authenticationService;
     private IRepository<SystemAdmin> systemAdminRepo;
+    private final IPaymentGateway paymentGateway;
+    private final ITicketGateway ticketGateway;
 
-    public AdminManagementService(IAuthenticationService authenticationService, IProductionCompanyRepository productionCompanyRepository, OrderRepositoryMapImpl orderRepo, IEventRepository eventRepo, IRepository<User> userRepository, IRepository<SystemAdmin> systemAdminRepo) {
+    public AdminManagementService(IAuthenticationService authenticationService, IProductionCompanyRepository productionCompanyRepository, OrderRepositoryMapImpl orderRepo, IEventRepository eventRepo, IRepository<User> userRepository, IRepository<SystemAdmin> systemAdminRepo, IPaymentGateway paymentGateway, ITicketGateway ticketGateway) {
         this.authenticationService = authenticationService;
         this.productionCompanyRepo=productionCompanyRepository;
         this.orderRepo = orderRepo;
         this.eventRepo = eventRepo;
         this.userRepository = userRepository;
         this.systemAdminRepo = systemAdminRepo;
+        this.paymentGateway=paymentGateway;
+        this.ticketGateway=ticketGateway;
     }
 
 
@@ -238,10 +244,86 @@ public class AdminManagementService {
     private void deactivateEvents(List<Event> events) {
         logger.info("AdminManagementService.deactivateEvents: Deactivating {} events", events.size());
         for (Event e : events) {
-            e.deactivateEvent();
+            deactivateEventAndRefundUser(e.getEventID());
             logger.info("AdminManagementService.deactivateEvents: Deactivated event with ID {}", e.getEventID());
         }
     }
+    private void deactivateEventAndRefundUser(int eventID)
+    {
+         logger.info("AdminManagementService.deactivateEventAndRefundUser: Deactivating event {}", eventID);
+         try{
+            while(true){
+                try{
+                    Event event=eventRepo.findByID(String.valueOf(eventID));
+                    event.deactivateEvent();
+                    eventRepo.save(event);
+                    break;
+                } catch(OptimisticLockingFailureException e){
+                    logger.warn("AdminManagementService.deactivateEventAndRefundUser: optimistic lock exception when saving event {}",eventID);
+                    continue;
+
+                } catch (IllegalArgumentException e){
+                    logger.warn("AdminManagementService.deactivateEventAndRefundUser: IllegalArgumentException: {}",e.getMessage());
+                    return;
+                } catch (IllegalStateException e){
+                    logger.warn("AdminManagementService.deactivateEventAndRefundUser: IllegalStateException: {}",e.getMessage());
+                    break;
+                }
+            }
+             logger.info("AdminManagementService.deactivateEventAndRefundUser: Deactivated event {}", eventID);
+            List<Order> orders=orderRepo.getByEventId(eventID);
+            for(Order order : orders)
+            {
+                if(cancelOrder(order.getOrderId()))
+                    refundOrder(order.getOrderId());
+            }
+
+
+         } catch(Exception e){
+            
+         }
+    }
+
+    private boolean cancelOrder(String orderID)
+    {
+        logger.info("AdminManagementService.cancelOrder: canceling order: {}", orderID);
+        while(true)
+        {   
+            try{
+                Order order= orderRepo.findByID(orderID);
+                boolean toRefund=false;
+
+                if(order.isActive()){ //only cancel
+                    order.CancelOrder();
+                }
+                else if(order.isCompleted())
+                { //refund
+                    order.CancelOrder();
+                    toRefund=true;
+                }
+                else{ //already canceled
+                    logger.info("AdminManagementService.cancelOrder: order {} was already canceled", orderID);
+                    return false;
+                }
+                orderRepo.save(order);
+                return toRefund;
+
+            } catch(OptimisticLockingFailureException e){
+                logger.warn("AdminManagementService.cancelOrder: concurency issue while canceling order: {}", orderID);
+                continue;
+            } catch(IllegalArgumentException e){
+                logger.warn("AdminManagementService.cancelOrder: IllegalArgumentException: {}", e.getMessage());
+                return false;
+            }
+        }
+    } 
+    
+
+    private void refundOrder(String orderID)
+    {
+        logger.info("AdminManagementService.refundOrder: refunding order: {}", orderID);
+
+    } 
 
     public Result<String> registerNewAdmin(String sToken, String newAdminUsername, String newAdminPassword, String newAdminEmail){
         try{

--- a/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
@@ -130,6 +130,7 @@ public class AdminManagementService {
             List<Order> orders = orderRepo.getAll();
             orders = orders.stream()
                     .filter(order -> order.isBelongsToSubject(userId + ""))
+                    .filter(order -> order.isCompleted())
                     .collect(Collectors.toList());
             List<OrderDTO> orderDTOs = orders.stream()
                     .map(order -> new OrderDTO(order))

--- a/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
@@ -251,11 +251,11 @@ public class AdminManagementService {
     private void deactivateEvents(List<Event> events) {
         logger.info("AdminManagementService.deactivateEvents: Deactivating {} events", events.size());
         for (Event e : events) {
-            deactivateEventAndRefundUser(e.getEventID());
+            deactivateEventAndRefundOrders(e.getEventID());
             logger.info("AdminManagementService.deactivateEvents: Deactivated event with ID {}", e.getEventID());
         }
     }
-    private void deactivateEventAndRefundUser(int eventID)
+    private void deactivateEventAndRefundOrders(int eventID)
     {
          logger.info("AdminManagementService.deactivateEventAndRefundUser: Deactivating event {}", eventID);
          try{

--- a/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
@@ -97,13 +97,14 @@ public class AdminManagementService {
             }
 
             List<Order> orders = orderRepo.getAll();
-            for (Order order : orders) {
-                Event event = eventRepo.findByID(String.valueOf(order.getEventId()));
-                if (event.getEventProductionCompanyID() != productionCompanyID) {
-                    orders.remove(order);
-                }
-            }
-            List<OrderDTO> orderDTOs = orders.stream()
+            List<Order> filtered = orders.stream()
+                .filter(order -> {
+                    Event event = eventRepo.findByID(String.valueOf(order.getEventId()));
+                    return event.getEventProductionCompanyID() == productionCompanyID && order.isCompleted();
+                })
+                .toList();
+
+            List<OrderDTO> orderDTOs = filtered.stream()
                     .map(order -> new OrderDTO(order))
                     .collect(Collectors.toList());
             return Result.makeOk(orderDTOs);

--- a/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
+++ b/src/main/java/com/group16b/ApplicationLayer/AdminManagementService.java
@@ -10,11 +10,17 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
 import com.group16b.ApplicationLayer.DTOs.ProductionCompanyDTO;
 import com.group16b.ApplicationLayer.DTOs.UserDTO;
+import com.group16b.ApplicationLayer.Enums.RefundStatus;
 import com.group16b.ApplicationLayer.Exceptions.AuthException;
+import com.group16b.ApplicationLayer.Exceptions.RefundFailedException;
+import com.group16b.ApplicationLayer.Exceptions.RefundStatusUnknownException;
+import com.group16b.ApplicationLayer.Exceptions.RevokeTicketFailureException;
+import com.group16b.ApplicationLayer.Exceptions.TicketRevokeUnknownStatusException;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.ApplicationLayer.Interfaces.IPaymentGateway;
 import com.group16b.ApplicationLayer.Interfaces.ITicketGateway;
 import com.group16b.ApplicationLayer.Objects.Result;
+import com.group16b.ApplicationLayer.Records.RefundResult;
 import com.group16b.DomainLayer.Event.Event;
 import com.group16b.DomainLayer.Event.IEventRepository;
 import com.group16b.DomainLayer.Interfaces.IRepository;
@@ -270,7 +276,8 @@ public class AdminManagementService {
                     break;
                 }
             }
-             logger.info("AdminManagementService.deactivateEventAndRefundUser: Deactivated event {}", eventID);
+
+            logger.info("AdminManagementService.deactivateEventAndRefundUser: Deactivated event {}", eventID);
             List<Order> orders=orderRepo.getByEventId(eventID);
             for(Order order : orders)
             {
@@ -284,6 +291,7 @@ public class AdminManagementService {
          }
     }
 
+    //cancel the order and return whether a refund is needed or not
     private boolean cancelOrder(String orderID)
     {
         logger.info("AdminManagementService.cancelOrder: canceling order: {}", orderID);
@@ -319,10 +327,33 @@ public class AdminManagementService {
     } 
     
 
-    private void refundOrder(String orderID)
+    private RefundResult refundOrder(String orderID)
     {
         logger.info("AdminManagementService.refundOrder: refunding order: {}", orderID);
-
+        try{
+            Order order= orderRepo.findByID(orderID);
+            paymentGateway.cancelPayment(order.getTransactionId());
+            ticketGateway.revokeTicket(order.getExternalTicket());
+            return new RefundResult(orderID,RefundStatus.SUCCESS,null);
+        } catch (IllegalArgumentException e){
+            logger.warn("AdminManagementService.refundOrder: IllegalArgumentException: {}",e.getMessage());
+            return new RefundResult(orderID,RefundStatus.DATA_INTEGRITY_ERROR ,e.getMessage());
+        } catch (RefundFailedException e){
+            logger.warn("AdminManagementService.refundOrder: RefundFailedException: {}",e.getMessage());
+            return new RefundResult(orderID,RefundStatus.REFUND_FAIL,e.getMessage());
+        } catch (RevokeTicketFailureException e){
+            logger.warn("AdminManagementService.refundOrder: RevokeTicketFailureException: {}",e.getMessage());
+            return new RefundResult(orderID,RefundStatus.TICKET_FAIL,e.getMessage());
+        } catch (RefundStatusUnknownException e){
+            logger.error("AdminManagementService.refundOrder: RefundStatusUnknownException: manual review requiered: ",e);
+            return new RefundResult(orderID,RefundStatus.REFUND_FAIL,e.getMessage());
+        } catch (TicketRevokeUnknownStatusException e){
+            logger.error("AdminManagementService.refundOrder: TicketRevokeUnknownStatusException: manual review requiered: ",e);
+            return new RefundResult(orderID,RefundStatus.TICKET_FAIL,e.getMessage());
+        } catch (Exception e){
+            logger.error("AdminManagementService.refundOrder: Unexpected Exception while refunding order: {}. error: ", orderID,e);
+            return new RefundResult(orderID,RefundStatus.UNKNOWN,e.getMessage());
+        }
     } 
 
     public Result<String> registerNewAdmin(String sToken, String newAdminUsername, String newAdminPassword, String newAdminEmail){

--- a/src/main/java/com/group16b/ApplicationLayer/Enums/RefundStatus.java
+++ b/src/main/java/com/group16b/ApplicationLayer/Enums/RefundStatus.java
@@ -1,0 +1,9 @@
+package com.group16b.ApplicationLayer.Enums;
+
+public enum RefundStatus {
+    SUCCESS,
+    REFUND_FAIL,
+    TICKET_FAIL,
+    DATA_INTEGRITY_ERROR,
+    UNKNOWN
+}

--- a/src/main/java/com/group16b/ApplicationLayer/Records/RefundResult.java
+++ b/src/main/java/com/group16b/ApplicationLayer/Records/RefundResult.java
@@ -1,0 +1,7 @@
+package com.group16b.ApplicationLayer.Records;
+
+import com.group16b.ApplicationLayer.Enums.RefundStatus;
+
+public record RefundResult(String orderId, RefundStatus status, String errorMessage ) {
+    
+}

--- a/src/main/java/com/group16b/DomainLayer/Order/IOrderRepository.java
+++ b/src/main/java/com/group16b/DomainLayer/Order/IOrderRepository.java
@@ -8,4 +8,5 @@ public interface IOrderRepository extends IRepository<Order> {
     List<Order> getBySubjectId(String subjectId);
     List<Order> getCompletedByEventIdSeatIds(int eventId, String segmentId, List<String> seatIds);
     List<Order> getCompletedByEventIdField(int eventId, String segmentId);
+    List<Order> getByEventId(int eventId);
     }

--- a/src/main/java/com/group16b/DomainLayer/Order/Order.java
+++ b/src/main/java/com/group16b/DomainLayer/Order/Order.java
@@ -98,6 +98,8 @@ public class Order {
 		this.eventId = other.eventId;
 		this.subjectID = other.subjectID;
 		this.version = other.version;
+		this.transactioId=other.transactioId;
+		this.externalTicket=other.externalTicket;
 		
 	}
 

--- a/src/main/java/com/group16b/InfrastructureLayer/MapDBs/OrderRepositoryMapImpl.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/MapDBs/OrderRepositoryMapImpl.java
@@ -84,6 +84,16 @@ public class OrderRepositoryMapImpl implements IOrderRepository {
 	}
 
 	@Override
+	public List<Order> getByEventId(int eventId)
+	{
+		return this.orders.values().stream()
+				.filter(Order::isCompleted)
+				.filter(order -> order.getEventId() == eventId)
+				.map(Order::new)
+				.toList();
+	}
+
+	@Override
 	public synchronized void delete(String orderId) {
 		if (this.orders.containsKey(orderId)) {
 			Order current = this.orders.get(orderId);

--- a/src/main/java/com/group16b/InfrastructureLayer/MapDBs/OrderRepositoryMapImpl.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/MapDBs/OrderRepositoryMapImpl.java
@@ -88,7 +88,6 @@ public class OrderRepositoryMapImpl implements IOrderRepository {
 	public List<Order> getByEventId(int eventId)
 	{
 		return this.orders.values().stream()
-				.filter(Order::isCompleted)
 				.filter(order -> order.getEventId() == eventId)
 				.map(Order::new)
 				.toList();

--- a/src/main/java/com/group16b/InfrastructureLayer/MapDBs/OrderRepositoryMapImpl.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/MapDBs/OrderRepositoryMapImpl.java
@@ -1,5 +1,6 @@
 package com.group16b.InfrastructureLayer.MapDBs;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,9 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+spring.autoconfigure.exclude=\
+org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
+org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
+spring.data.jpa.repositories.enabled=false

--- a/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
@@ -117,12 +117,18 @@ public class AdminManagementServiceTests {
         myActiveEvent.activateEvent();
         eventRepository.save(myActiveEvent);
 
+        ProductionCompany someRnadomCompany=new ProductionCompany(10042,"ra",2.1,"rand");
+        productionCompanyRepository.save(someRnadomCompany);
+
+        Event randomAssEvent=new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 10042, 3.5), USER2_MAIL);
+        eventRepository.save(randomAssEvent);
+
         myActiveOrder=new Order("segment1", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
         myCompletedOrder=new Order("segment2", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
         myCompletedOrder.CompleteOrder();
         myCanceledOrder=new Order("segment3", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
         myCanceledOrder.CancelOrder();
-        unrelatedCompletedOrder=new Order("segment2", 1, 1.0, myActiveEvent.getEventID(),USER2_MAIL);
+        unrelatedCompletedOrder=new Order("segment2", 1, 1.0, randomAssEvent.getEventID(),USER2_MAIL);
         unrelatedCompletedOrder.CompleteOrder();
         orderRepository.save(myActiveOrder);
         orderRepository.save(myCompletedOrder);
@@ -351,8 +357,8 @@ public class AdminManagementServiceTests {
         assertEquals(2, results.size());
         assertTrue(results.get(0).isSuccess());
         assertTrue(results.get(1).isSuccess());
-        assertEquals(1, results.get(0).getValue().size());
-        assertEquals(1, results.get(1).getValue().size());
+        assertEquals(2, results.get(0).getValue().size());
+        assertEquals(2, results.get(1).getValue().size());
     }
 
     @Test

--- a/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
@@ -15,7 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -23,6 +26,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
+import com.group16b.ApplicationLayer.Exceptions.RefundFailedException;
+import com.group16b.ApplicationLayer.Exceptions.RefundStatusUnknownException;
+import com.group16b.ApplicationLayer.Exceptions.RevokeTicketFailureException;
+import com.group16b.ApplicationLayer.Exceptions.TicketRevokeUnknownStatusException;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
 import com.group16b.ApplicationLayer.Interfaces.IPaymentGateway;
 import com.group16b.ApplicationLayer.Interfaces.ITicketGateway;
@@ -195,24 +202,6 @@ public class AdminManagementServiceTests {
     }
 
     @Test
-    public void testCloseProductionCompanySuccess() throws Exception {
-        int companyID = 1;
-
-        Field policyField = adminManagementService.getClass().getDeclaredField("productionCompanyRepo");
-        ProductionCompany testCompany = new ProductionCompany(companyID, "prodTest", 5, "1"); 
-        productionCompanyRepository.save(testCompany);
-
-        policyField.setAccessible(true);
-        policyField.set(adminManagementService, productionCompanyRepository);
-        
-        Result<String> result = adminManagementService.closeProductionCompany(companyID, adminToken);
-
-        assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
-        verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
-        verify(mockTicketGateway,times(1)).revokeTicket(EXTERNAL_TICKET);
-    }
-
-    @Test
     public void testViewAllPurchaseHistoryEmptyHistory() {
         User newUser = new User("newuser@example.com", "password123");
         Result<List<OrderDTO>> history = adminManagementService.viewPurchesHistoryByUser(adminToken,
@@ -248,10 +237,104 @@ public class AdminManagementServiceTests {
     }
 
     @Test
+    public void testCloseProductionCompanySuccess() throws Exception {
+        int companyID = 1;
+
+        Field policyField = adminManagementService.getClass().getDeclaredField("productionCompanyRepo");
+        ProductionCompany testCompany = new ProductionCompany(companyID, "prodTest", 5, "1"); 
+        productionCompanyRepository.save(testCompany);
+
+        policyField.setAccessible(true);
+        policyField.set(adminManagementService, productionCompanyRepository);
+        
+        Result<String> result = adminManagementService.closeProductionCompany(companyID, adminToken);
+
+        assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
+        verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
+        verify(mockTicketGateway,times(1)).revokeTicket(anyString());
+    }
+    
+    @Test
+    public void testCloseProductionCompany_paymentServiceDown() throws Exception {
+        int companyID = 1;
+
+        doThrow(new RefundStatusUnknownException("kaboom rico")).when(mockPaymentGateway).cancelPayment(anyInt());
+        Field policyField = adminManagementService.getClass().getDeclaredField("productionCompanyRepo");
+        ProductionCompany testCompany = new ProductionCompany(companyID, "prodTest", 5, "1"); 
+        productionCompanyRepository.save(testCompany);
+
+        policyField.setAccessible(true);
+        policyField.set(adminManagementService, productionCompanyRepository);
+        
+        Result<String> result = adminManagementService.closeProductionCompany(companyID, adminToken);
+
+        assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
+        verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
+        verify(mockTicketGateway,never()).revokeTicket(anyString());
+    }
+    @Test
+    public void testCloseProductionCompany_paymentServiceRefuse() throws Exception {
+        int companyID = 1;
+
+        doThrow(new RefundFailedException("kaboom rico")).when(mockPaymentGateway).cancelPayment(anyInt());
+        Field policyField = adminManagementService.getClass().getDeclaredField("productionCompanyRepo");
+        ProductionCompany testCompany = new ProductionCompany(companyID, "prodTest", 5, "1"); 
+        productionCompanyRepository.save(testCompany);
+
+        policyField.setAccessible(true);
+        policyField.set(adminManagementService, productionCompanyRepository);
+        
+        Result<String> result = adminManagementService.closeProductionCompany(companyID, adminToken);
+
+        assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
+        verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
+        verify(mockTicketGateway,never()).revokeTicket(anyString());
+    }
+
+    @Test
+    public void testCloseProductionCompany_ticketServiceDown() throws Exception {
+        int companyID = 1;
+
+        doThrow(new TicketRevokeUnknownStatusException("kaboom rico")).when(mockTicketGateway).revokeTicket(anyString());
+        Field policyField = adminManagementService.getClass().getDeclaredField("productionCompanyRepo");
+        ProductionCompany testCompany = new ProductionCompany(companyID, "prodTest", 5, "1"); 
+        productionCompanyRepository.save(testCompany);
+
+        policyField.setAccessible(true);
+        policyField.set(adminManagementService, productionCompanyRepository);
+        
+        Result<String> result = adminManagementService.closeProductionCompany(companyID, adminToken);
+
+        assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
+        verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
+        verify(mockTicketGateway,times(1)).revokeTicket(anyString());
+    }
+    @Test
+    public void testCloseProductionCompany_ticketServiceReject() throws Exception {
+        int companyID = 1;
+
+        doThrow(new RevokeTicketFailureException("kaboom rico")).when(mockTicketGateway).revokeTicket(anyString());
+        Field policyField = adminManagementService.getClass().getDeclaredField("productionCompanyRepo");
+        ProductionCompany testCompany = new ProductionCompany(companyID, "prodTest", 5, "1"); 
+        productionCompanyRepository.save(testCompany);
+
+        policyField.setAccessible(true);
+        policyField.set(adminManagementService, productionCompanyRepository);
+        
+        Result<String> result = adminManagementService.closeProductionCompany(companyID, adminToken);
+
+        assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
+        verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
+        verify(mockTicketGateway,times(1)).revokeTicket(anyString());
+    }
+
+    @Test
     public void testCloseProductionCompanyUnauthorized() {
 
         Result<String> result = adminManagementService.closeProductionCompany(1, sessionToken);
         assertFalse(result.isSuccess());
+        verify(mockPaymentGateway,never()).cancelPayment(anyInt());
+        verify(mockTicketGateway,never()).revokeTicket(anyString());
     }
 
     @Test
@@ -441,6 +524,8 @@ public class AdminManagementServiceTests {
         assertEquals(2, results.size());
         long successCount = results.stream().filter(Result::isSuccess).count();
         assertEquals(1, successCount, "Exactly one closure should succeed");
+        verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
+        verify(mockTicketGateway,times(1)).revokeTicket(anyString());
     }
     @Test
     public void testRegisterNewAdminNullToken() {
@@ -484,18 +569,24 @@ public class AdminManagementServiceTests {
     public void testCloseProductionCompanyInvalidToken() {
         Result<String> result = adminManagementService.closeProductionCompany(1, invalidToken);
         assertFalse(result.isSuccess());
+        verify(mockPaymentGateway,never()).cancelPayment(anyInt());
+        verify(mockTicketGateway,never()).revokeTicket(anyString());
     }
 
     @Test
     public void testCloseProductionCompanyNullToken() {
         Result<String> result = adminManagementService.closeProductionCompany(1, null);
         assertFalse(result.isSuccess());
+        verify(mockPaymentGateway,never()).cancelPayment(anyInt());
+        verify(mockTicketGateway,never()).revokeTicket(anyString());
     }
 
     @Test
     public void testCloseNonExistentProductionCompany() {
         Result<String> result = adminManagementService.closeProductionCompany(99999, adminToken);
         assertFalse(result.isSuccess());
+        verify(mockPaymentGateway,never()).cancelPayment(anyInt());
+        verify(mockTicketGateway,never()).revokeTicket(anyString());
     }
 
     @Test
@@ -620,6 +711,9 @@ public class AdminManagementServiceTests {
 
         assertTrue(first.isSuccess());
         assertFalse(second.isSuccess());
+        //company 2, some random ass company with no orders
+        verify(mockPaymentGateway,never()).cancelPayment(anyInt());
+        verify(mockTicketGateway,never()).revokeTicket(anyString());
     }
 
     @Test

--- a/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
@@ -66,11 +66,13 @@ public class AdminManagementServiceTests {
     private Segment segment1;
     private Venue venue1;
     private Event e1;
-    private Order activeOrder;
-    private Order completedOrder;
-    private Order canceledOrder;
+    private Order myActiveOrder;
+    private Order myCompletedOrder;
+    private Order myCanceledOrder;
     private Order unrelatedCompletedOrder;
+    private Event myActiveEvent;
     private User user;
+    private String USER2_MAIL="miki mahus";
     private String sessionToken;
     private String adminToken;
     private String invalidToken;
@@ -111,18 +113,22 @@ public class AdminManagementServiceTests {
 
         
         e1 = new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 1, 3.5), user.getEmail());
-        
-        activeOrder=new Order("segment1", 1, 1.0, e1.getEventID(), String.valueOf(user.getEmail()));
-        completedOrder=new Order("segment2", 1, 1.0, e1.getEventID(), String.valueOf(user.getEmail()));
-        completedOrder.CompleteOrder();
-        canceledOrder=new Order("segment3", 1, 1.0, e1.getEventID(), String.valueOf(user.getEmail()));
-        canceledOrder.CancelOrder();
-        unrelatedCompletedOrder=new Order("segment2", 1, 1.0, e1.getEventID(), String.valueOf(user.getEmail()));
+        myActiveEvent=new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 1, 3.5), USER2_MAIL);
+        myActiveEvent.activateEvent();
+        eventRepository.save(myActiveEvent);
+
+        myActiveOrder=new Order("segment1", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
+        myCompletedOrder=new Order("segment2", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
+        myCompletedOrder.CompleteOrder();
+        myCanceledOrder=new Order("segment3", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
+        myCanceledOrder.CancelOrder();
+        unrelatedCompletedOrder=new Order("segment2", 1, 1.0, myActiveEvent.getEventID(),USER2_MAIL);
         unrelatedCompletedOrder.CompleteOrder();
-        orderRepository.save(activeOrder);
-        orderRepository.save(completedOrder);
-        orderRepository.save(canceledOrder);
+        orderRepository.save(myActiveOrder);
+        orderRepository.save(myCompletedOrder);
+        orderRepository.save(myCanceledOrder);
         orderRepository.save(unrelatedCompletedOrder);
+
     }
 
     // Helper method to keep reflection injection clean

--- a/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
@@ -66,6 +66,10 @@ public class AdminManagementServiceTests {
     private Segment segment1;
     private Venue venue1;
     private Event e1;
+    private Order activeOrder;
+    private Order completedOrder;
+    private Order canceledOrder;
+    private Order unrelatedCompletedOrder;
     private User user;
     private String sessionToken;
     private String adminToken;
@@ -105,10 +109,20 @@ public class AdminManagementServiceTests {
         LocalDateTime startTime = LocalDateTime.now().plusDays(1);
         LocalDateTime endTime = LocalDateTime.now().plusDays(2);
 
-        e1 = new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 1, 3.5),
-                user.getEmail());
         
         e1 = new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 1, 3.5), user.getEmail());
+        
+        activeOrder=new Order("segment1", 1, 1.0, e1.getEventID(), String.valueOf(user.getEmail()));
+        completedOrder=new Order("segment2", 1, 1.0, e1.getEventID(), String.valueOf(user.getEmail()));
+        completedOrder.CompleteOrder();
+        canceledOrder=new Order("segment3", 1, 1.0, e1.getEventID(), String.valueOf(user.getEmail()));
+        canceledOrder.CancelOrder();
+        unrelatedCompletedOrder=new Order("segment2", 1, 1.0, e1.getEventID(), String.valueOf(user.getEmail()));
+        unrelatedCompletedOrder.CompleteOrder();
+        orderRepository.save(activeOrder);
+        orderRepository.save(completedOrder);
+        orderRepository.save(canceledOrder);
+        orderRepository.save(unrelatedCompletedOrder);
     }
 
     // Helper method to keep reflection injection clean

--- a/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
@@ -14,7 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,6 +82,9 @@ public class AdminManagementServiceTests {
     private String userSecret;
     private String adminSecret;
 
+    private final int TRANS_ID=12345;
+    private final String EXTERNAL_TICKET="when one door closes, another door always opens, its the last time i buy a closet frim ikea...";
+
     @BeforeEach
     void setUp() throws Exception {
         systemAdminRepository = new SystemAdminRepositoryMapImpl();
@@ -123,11 +129,15 @@ public class AdminManagementServiceTests {
         Event randomAssEvent=new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 10042, 3.5), USER2_MAIL);
         eventRepository.save(randomAssEvent);
 
-        myActiveOrder=new Order("segment1", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
-        myCompletedOrder=new Order("segment2", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
+        myActiveOrder=new Order("my ACTIVE 1", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
+        myCompletedOrder=new Order("my COMPLETED", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
         myCompletedOrder.CompleteOrder();
-        myCanceledOrder=new Order("segment3", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
+        myCompletedOrder.setExternalTicket(EXTERNAL_TICKET);
+        myCompletedOrder.setTransactionId(TRANS_ID);
+        myCanceledOrder=new Order("my CANCEL", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
         myCanceledOrder.CancelOrder();
+        myCanceledOrder.setExternalTicket(EXTERNAL_TICKET);
+        myCanceledOrder.setTransactionId(TRANS_ID);
         unrelatedCompletedOrder=new Order("segment2", 1, 1.0, randomAssEvent.getEventID(),USER2_MAIL);
         unrelatedCompletedOrder.CompleteOrder();
         orderRepository.save(myActiveOrder);
@@ -198,6 +208,8 @@ public class AdminManagementServiceTests {
         Result<String> result = adminManagementService.closeProductionCompany(companyID, adminToken);
 
         assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
+        verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
+        verify(mockTicketGateway,times(1)).revokeTicket(EXTERNAL_TICKET);
     }
 
     @Test

--- a/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
@@ -91,6 +91,7 @@ public class AdminManagementServiceTests {
     private String adminSecret;
 
     private final int TRANS_ID=12345;
+    private final int REFUNDLESS_COMPANY_ID=10034;
     private final String EXTERNAL_TICKET="when one door closes, another door always opens, its the last time i buy a closet frim ikea...";
 
     @BeforeEach
@@ -132,10 +133,10 @@ public class AdminManagementServiceTests {
         myActiveEvent.activateEvent();
         eventRepository.save(myActiveEvent);
 
-        ProductionCompany someRnadomCompany=new ProductionCompany(10042,"ra",2.1,"rand");
+        ProductionCompany someRnadomCompany=new ProductionCompany(REFUNDLESS_COMPANY_ID,"ra",2.1,"rand");
         productionCompanyRepository.save(someRnadomCompany);
 
-        Event randomAssEvent=new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 10042, 3.5), USER2_MAIL);
+        Event randomAssEvent=new Event(new EventRecord("venue1", "event1", LocalDateTime.now().minusDays(1), endTime, "artist1", "category1", REFUNDLESS_COMPANY_ID, 3.5), USER2_MAIL);
         eventRepository.save(randomAssEvent);
 
         myActiveOrder=new Order("my ACTIVE 1", 1, 1.0, myActiveEvent.getEventID(), USER2_MAIL);
@@ -149,6 +150,8 @@ public class AdminManagementServiceTests {
         myCanceledOrder.setTransactionId(TRANS_ID);
         unrelatedCompletedOrder=new Order("segment2", 1, 1.0, randomAssEvent.getEventID(),USER2_MAIL);
         unrelatedCompletedOrder.CompleteOrder();
+        unrelatedCompletedOrder.setExternalTicket(EXTERNAL_TICKET);
+        unrelatedCompletedOrder.setTransactionId(TRANS_ID);
         orderRepository.save(myActiveOrder);
         orderRepository.save(myCompletedOrder);
         orderRepository.save(myCanceledOrder);
@@ -254,6 +257,17 @@ public class AdminManagementServiceTests {
         assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
         verify(mockPaymentGateway,times(1)).cancelPayment(anyInt());
         verify(mockTicketGateway,times(1)).revokeTicket(anyString());
+    }
+
+    @Test
+    public void testCloseProductionCompany_onlyPassedEvents_SuccessAndNoRefunds() throws Exception {
+
+        
+        Result<String> result = adminManagementService.closeProductionCompany(REFUNDLESS_COMPANY_ID, adminToken);
+
+        assertTrue(result.isSuccess(), "Failed to close company: " + result.getError());
+        verify(mockPaymentGateway,never()).cancelPayment(anyInt());
+        verify(mockTicketGateway,never()).revokeTicket(anyString());
     }
     
     @Test

--- a/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
@@ -81,6 +81,7 @@ public class AdminManagementServiceTests {
     private Order myCanceledOrder;
     private Order unrelatedCompletedOrder;
     private Event myActiveEvent;
+    private Event myInactiveEvent;
     private User user;
     private String USER2_MAIL="miki mahus";
     private String sessionToken;
@@ -127,6 +128,7 @@ public class AdminManagementServiceTests {
         
         e1 = new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 1, 3.5), user.getEmail());
         myActiveEvent=new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 1, 3.5), USER2_MAIL);
+        myInactiveEvent=new Event(new EventRecord("venue1", "event1", startTime, endTime, "artist1", "category1", 1, 3.5), USER2_MAIL);
         myActiveEvent.activateEvent();
         eventRepository.save(myActiveEvent);
 

--- a/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
+++ b/src/test/java/com/group16b/ApplicationLayer/AdminManagementServiceTests.java
@@ -14,11 +14,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.group16b.ApplicationLayer.DTOs.OrderDTO;
 import com.group16b.ApplicationLayer.Interfaces.IAuthenticationService;
+import com.group16b.ApplicationLayer.Interfaces.IPaymentGateway;
+import com.group16b.ApplicationLayer.Interfaces.ITicketGateway;
 import com.group16b.ApplicationLayer.Objects.Result;
 import com.group16b.ApplicationLayer.Records.EventRecord;
 import com.group16b.DomainLayer.Event.Event;
@@ -55,6 +59,8 @@ public class AdminManagementServiceTests {
     private IRepository<User> userRepository;
     private OrderRepositoryMapImpl orderRepository;
     private IProductionCompanyRepository productionCompanyRepository;
+    private IPaymentGateway mockPaymentGateway;
+    private ITicketGateway mockTicketGateway;
 
     private Location location1;
     private Segment segment1;
@@ -78,7 +84,10 @@ public class AdminManagementServiceTests {
         userRepository = new UserRepositoryMapImpl();
         orderRepository = new OrderRepositoryMapImpl(); 
         productionCompanyRepository = new ProductionCompanyRepositoryMapImpl();
-        adminManagementService = new AdminManagementService(tokenService,productionCompanyRepository, orderRepository, eventRepository, userRepository, systemAdminRepository);
+
+        mockPaymentGateway=mock(IPaymentGateway.class);
+        mockTicketGateway=mock(ITicketGateway.class);
+        adminManagementService = new AdminManagementService(tokenService,productionCompanyRepository, orderRepository, eventRepository, userRepository, systemAdminRepository,mockPaymentGateway,mockTicketGateway);
             
         user = new User("testuser", "password");
         adminToken = tokenService.generateAdminToken("admin@test.com");


### PR DESCRIPTION
made it that upon the deletion of a company, deactivate all its events, and if an event was yet to happen, also refund all the tickets
added some tests
added a method to order repo, of get all event orders, as it feels more correct than manually filtering in the service
fixed some bugs