### PR TITLE
632 optimize venue loading 

### DIFF
--- a/src/main/java/com/group16b/DomainLayer/Venue/Seat.java
+++ b/src/main/java/com/group16b/DomainLayer/Venue/Seat.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.hibernate.annotations.BatchSize;
+
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -22,6 +24,7 @@ public class Seat {
     private int number;
 
     // --- ADD THE Jpa Mapping Strategy Here ---
+	@BatchSize(size = 100)
     @ElementCollection
     @CollectionTable(
         name = "seat_stock", 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.port=8080
 # spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,...
 # spring.data.jpa.repositories.enabled=false
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.url=jdbc:postgresql://localhost:15432/postgres
 
 spring.datasource.username=postgres
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.port=8080
 # spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,...
 # spring.data.jpa.repositories.enabled=false
 
-spring.datasource.url=jdbc:postgresql://localhost:15432/postgres
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
 
 spring.datasource.username=postgres
 


### PR DESCRIPTION
added batches, the main issue is seating stock in seat, because its an elementcollection, it does not participate well in join and entity graphs, batches do reduce fetch count by x100 so loading a venue now is fast enough, comperable to loading events and p companies
but it does not solve slow updates and creations, as hibernate still insists on a lot of queries, 1 query per stock, sadly i lack the knowledge on how to improve it fast enough, as my main idea, is a small overhaul like adding a seperate global list of stock per seat per event, but it does mean tests and changes