### PR TITLE
644 fix the exception catching for missing entity not found in db

### DIFF
--- a/src/main/java/com/group16b/ApiLayer/BaseController.java
+++ b/src/main/java/com/group16b/ApiLayer/BaseController.java
@@ -28,11 +28,13 @@ public class BaseController {
             return ResponseEntity.badRequest().body(result.getError());
 
         } catch (DataAccessException e) {
-            System.out.println("Base Controller: DataAccessException: " + e.getMessage());
+            System.out.println("Base Controller: DataAccessException: " + e.getMessage()+", exception type: "+e.getClass());
+            System.out.println(e);
             return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
 
         } catch (Exception e) {
-            System.out.println("Base Controller: Unexpected exception: " + e.getMessage());
+            System.out.println("Base Controller: Unexpected exception: " + e.getMessage()+", exception type: "+e.getClass());
+            System.out.println(e);
             return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
         }
     }

--- a/src/main/java/com/group16b/ApiLayer/BaseController.java
+++ b/src/main/java/com/group16b/ApiLayer/BaseController.java
@@ -9,39 +9,30 @@ import com.group16b.ApplicationLayer.Objects.Result;
 
 public class BaseController {
     protected <T> ResponseEntity<?> executeWithReturnData(Supplier<Result<T>> action) {
-        try {
-            System.out.println("base controller,right before get");
-            Result<T> result = action.get();
-
-            if (result.isSuccess()) {
-                return ResponseEntity.ok(result.getValue());
-            }
-            else{
-                return ResponseEntity.badRequest().body(result.getError());
-            }
-
-        } catch (DataAccessException e) {
-            System.out.println("Base Controller: DataAccessException: "+e.getMessage()+", type: "+e.getClass());
-            return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
-        } catch (Exception e) {
-            System.out.println("Base Controller: Unexpected exception: "+e.getMessage()+", type: "+e.getClass());
-            return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
-        }
+        return execute(action,result -> ResponseEntity.ok(result.getValue()));
     }
 
     protected <T> ResponseEntity<?> executeWithNoReturnData(Supplier<Result<T>> action) {
+        return execute(action, result -> ResponseEntity.ok().build());
+    }
+
+    protected <T> ResponseEntity<?> execute(Supplier<Result<T>> action,
+            java.util.function.Function<Result<T>, ResponseEntity<?>> onSuccess) {
         try {
             Result<T> result = action.get();
 
             if (result.isSuccess()) {
-                return ResponseEntity.ok().build();
+                return onSuccess.apply(result);
             }
+
             return ResponseEntity.badRequest().body(result.getError());
+
         } catch (DataAccessException e) {
-            System.out.println("Base Controller: DataAccessException: "+e.getMessage()+", type: "+e.getClass());
+            System.out.println("Base Controller: DataAccessException: " + e.getMessage());
             return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
+
         } catch (Exception e) {
-            System.out.println("Base Controller: Unexpected exception: "+e.getMessage()+", type: "+e.getClass());
+            System.out.println("Base Controller: Unexpected exception: " + e.getMessage());
             return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
         }
     }

--- a/src/main/java/com/group16b/ApiLayer/BaseController.java
+++ b/src/main/java/com/group16b/ApiLayer/BaseController.java
@@ -2,6 +2,7 @@ package com.group16b.ApiLayer;
 
 import java.util.function.Supplier;
 
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
 
 import com.group16b.ApplicationLayer.Objects.Result;
@@ -9,6 +10,7 @@ import com.group16b.ApplicationLayer.Objects.Result;
 public class BaseController {
     protected <T> ResponseEntity<?> executeWithReturnData(Supplier<Result<T>> action) {
         try {
+            System.out.println("base controller,right before get");
             Result<T> result = action.get();
 
             if (result.isSuccess()) {
@@ -18,9 +20,12 @@ public class BaseController {
                 return ResponseEntity.badRequest().body(result.getError());
             }
 
+        } catch (DataAccessException e) {
+            System.out.println("Base Controller: DataAccessException: "+e.getMessage()+", type: "+e.getClass());
+            return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
         } catch (Exception e) {
-            Result<T> errorResult = Result.makeFail("System error: " + e.getMessage());
-            return ResponseEntity.internalServerError().body(errorResult.getError());
+            System.out.println("Base Controller: Unexpected exception: "+e.getMessage()+", type: "+e.getClass());
+            return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
         }
     }
 
@@ -32,8 +37,14 @@ public class BaseController {
                 return ResponseEntity.ok().build();
             }
             return ResponseEntity.badRequest().body(result.getError());
+        } catch (DataAccessException e) {
+            System.out.println("Base Controller: DataAccessException: "+e.getMessage()+", type: "+e.getClass());
+            return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(e.getMessage());
+            System.out.println("Base Controller: Unexpected exception: "+e.getMessage()+", type: "+e.getClass());
+            return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
         }
     }
+
+    
 }

--- a/src/main/java/com/group16b/ApiLayer/BaseController.java
+++ b/src/main/java/com/group16b/ApiLayer/BaseController.java
@@ -2,12 +2,18 @@ package com.group16b.ApiLayer;
 
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
 
+import com.group16b.ApplicationLayer.EventService;
 import com.group16b.ApplicationLayer.Objects.Result;
 
 public class BaseController {
+    private static final Logger logger = LoggerFactory.getLogger(EventService.class);
+    private static final String SERVICE_DOWN ="Service temporarily unavailable. Please try again later";
+
     protected <T> ResponseEntity<?> executeWithReturnData(Supplier<Result<T>> action) {
         return execute(action,result -> ResponseEntity.ok(result.getValue()));
     }
@@ -28,14 +34,12 @@ public class BaseController {
             return ResponseEntity.badRequest().body(result.getError());
 
         } catch (DataAccessException e) {
-            System.out.println("Base Controller: DataAccessException: " + e.getMessage()+", exception type: "+e.getClass());
-            System.out.println(e);
-            return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
+            logger.error("Base controller: DataAccessException: ",e);
+            return ResponseEntity.internalServerError().body(SERVICE_DOWN);
 
         } catch (Exception e) {
-            System.out.println("Base Controller: Unexpected exception: " + e.getMessage()+", exception type: "+e.getClass());
-            System.out.println(e);
-            return ResponseEntity.internalServerError().body("Service temporarily unavailable. Please try again later");
+            logger.error("Base controller: Unexpected issue: ",e);
+            return ResponseEntity.internalServerError().body(SERVICE_DOWN);
         }
     }
 

--- a/src/main/java/com/group16b/ApiLayer/UserLoginController.java
+++ b/src/main/java/com/group16b/ApiLayer/UserLoginController.java
@@ -25,7 +25,7 @@ public class UserLoginController extends BaseController{
     public ResponseEntity<?> loginMember(@RequestBody LoginRequestDTO requestDTO,
                                          @RequestHeader("Authorization") String guestSessionToken
     ) {
-        
+        System.out.println("try to login");
         return executeWithReturnData(() -> userLoginService.loginMember(requestDTO.getEmail(), requestDTO.getPassword(), guestSessionToken));
     }
 

--- a/src/main/java/com/group16b/ApiLayer/UserLoginController.java
+++ b/src/main/java/com/group16b/ApiLayer/UserLoginController.java
@@ -25,7 +25,6 @@ public class UserLoginController extends BaseController{
     public ResponseEntity<?> loginMember(@RequestBody LoginRequestDTO requestDTO,
                                          @RequestHeader("Authorization") String guestSessionToken
     ) {
-        System.out.println("try to login");
         return executeWithReturnData(() -> userLoginService.loginMember(requestDTO.getEmail(), requestDTO.getPassword(), guestSessionToken));
     }
 

--- a/src/main/java/com/group16b/DomainLayer/Venue/Seat.java
+++ b/src/main/java/com/group16b/DomainLayer/Venue/Seat.java
@@ -4,8 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import org.hibernate.annotations.BatchSize;
-
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -24,7 +22,6 @@ public class Seat {
     private int number;
 
     // --- ADD THE Jpa Mapping Strategy Here ---
-	@BatchSize(size = 100)
     @ElementCollection
     @CollectionTable(
         name = "seat_stock", 

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/EventRepositoryAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/EventRepositoryAdapter.java
@@ -26,7 +26,7 @@ public class EventRepositoryAdapter implements IEventRepository {
     @Override
     public Event findByID(String id) {
         return springRepo.findById(id).orElseThrow(() -> 
-            new IllegalArgumentException("User with ID " + id + " not found.")
+            new IllegalArgumentException("Event with ID " + id + " not found.")
         );
     }
 

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/EventRepositoryAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/EventRepositoryAdapter.java
@@ -7,9 +7,9 @@ import com.group16b.DomainLayer.Event.IEventRepository;
 import org.springframework.context.annotation.Primary;
 import com.group16b.InfrastructureLayer.Database.EventRepositroy;
 
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
-@Repository
+@Component
 @Primary
 public class EventRepositoryAdapter implements IEventRepository {
     private final EventRepositroy springRepo;    

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/OrderRepositoryAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/OrderRepositoryAdapter.java
@@ -26,11 +26,9 @@ public class OrderRepositoryAdapter implements IOrderRepository {
 
     @Override
     public Order findByID(String id) {
-        try {
-            return springRepo.findById(id).get(); 
-        } catch (NoSuchElementException e) {
-            throw new IllegalArgumentException("Order with ID " + id + " not found.");
-        }
+        return springRepo.findById(id).orElseThrow(() -> 
+            new IllegalArgumentException("Order with ID " + id + " not found.")
+        );
     }
 
     @Override

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/OrderRepositoryAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/OrderRepositoryAdapter.java
@@ -2,15 +2,16 @@ package com.group16b.InfrastructureLayer.Adapters;
 
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
-import org.springframework.stereotype.Repository;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
 
 import com.group16b.DomainLayer.Order.IOrderRepository;
 import com.group16b.DomainLayer.Order.Order;
 import com.group16b.InfrastructureLayer.Database.OrderRepository;
 
-@Repository 
+@Component
+@Primary
 public class OrderRepositoryAdapter implements IOrderRepository {
 
     private final OrderRepository springRepo;

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/ProductionCompanyRepositoryAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/ProductionCompanyRepositoryAdapter.java
@@ -28,13 +28,9 @@ public class ProductionCompanyRepositoryAdapter implements IProductionCompanyRep
 
     @Override
     public ProductionCompany findByID(String id) {
-        try {
-            return springRepo.findById(Integer.parseInt(id)).get(); 
-        } catch (NoSuchElementException e) {
-            throw new IllegalArgumentException("Production Company with ID " + id + " not found.");
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Production Company ID must be a valid integer.");
-        }
+        return springRepo.findById(parseID(id)).orElseThrow(() -> 
+            new IllegalArgumentException("Company with ID " + id + " not found.")
+        );
     }
 
     @Override
@@ -44,11 +40,8 @@ public class ProductionCompanyRepositoryAdapter implements IProductionCompanyRep
 
     @Override
     public void delete(String id) {
-        try {
-            springRepo.deleteById(Integer.parseInt(id));
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Production Company ID must be a valid integer.");
-        }
+       springRepo.deleteById(parseID(id));
+        
     }
 
     @Override
@@ -70,5 +63,14 @@ public class ProductionCompanyRepositoryAdapter implements IProductionCompanyRep
     @Override
     public List<ProductionCompany> findCompaniesManagedByUser(String userId) {
         return springRepo.findCompaniesManagedByUser(userId);
+    }
+
+    private int parseID(String ID)
+    {
+        try{
+            return Integer.parseInt(ID);
+        } catch(NumberFormatException e){
+            throw new IllegalArgumentException("Invalid company ID: "+ID);
+        }
     }
 }

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/ProductionCompanyRepositoryAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/ProductionCompanyRepositoryAdapter.java
@@ -1,18 +1,17 @@
 package com.group16b.InfrastructureLayer.Adapters;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
 import com.group16b.DomainLayer.ProductionCompany.IProductionCompanyRepository;
 import com.group16b.DomainLayer.ProductionCompany.ProductionCompany;
 import com.group16b.DomainLayer.User.User;
 import com.group16b.InfrastructureLayer.Database.ProductionCompanyRepository;
 
-@Repository
-@Primary 
+@Component
+@Primary
 public class ProductionCompanyRepositoryAdapter implements IProductionCompanyRepository {
 
     private final ProductionCompanyRepository springRepo;

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/SystemAdminAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/SystemAdminAdapter.java
@@ -3,13 +3,13 @@ package com.group16b.InfrastructureLayer.Adapters;
 import java.util.List;
 
 import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
 import com.group16b.DomainLayer.Interfaces.IRepository;
 import com.group16b.DomainLayer.SystemAdmin.SystemAdmin;
 import com.group16b.InfrastructureLayer.Database.SystemAdminRepository;
 
-@Repository
+@Component
 @Primary
 public class SystemAdminAdapter  implements IRepository<SystemAdmin> {
     private final SystemAdminRepository springRepo;

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/UserRepositoryAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/UserRepositoryAdapter.java
@@ -1,7 +1,7 @@
 package com.group16b.InfrastructureLayer.Adapters;
 
 import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
 import com.group16b.DomainLayer.User.User;
 import com.group16b.DomainLayer.Interfaces.IRepository;
@@ -9,7 +9,7 @@ import com.group16b.InfrastructureLayer.Database.UserRepository;
 
 import java.util.List;
 
-@Repository
+@Component
 @Primary
 public class UserRepositoryAdapter implements IRepository<User>{
     private final UserRepository springRepo;

--- a/src/main/java/com/group16b/InfrastructureLayer/Adapters/VenueRepostoryAdapter.java
+++ b/src/main/java/com/group16b/InfrastructureLayer/Adapters/VenueRepostoryAdapter.java
@@ -3,13 +3,13 @@ package com.group16b.InfrastructureLayer.Adapters;
 import java.util.List;
 
 import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
 import com.group16b.DomainLayer.Interfaces.IRepository;
 import com.group16b.DomainLayer.Venue.Venue;
 import com.group16b.InfrastructureLayer.Database.VenueRepository;
 
-@Repository
+@Component
 @Primary
 public class VenueRepostoryAdapter implements IRepository<Venue>{
     private final VenueRepository springRepo;


### PR DESCRIPTION
fixed the exception thrown from the adapters, to not be caught by spring repo interceptor, and instead throw the expected illegal arg
refactored base controller, to eliminate duplication, and improved the return message to be safer
reverted the batching load for venue. i.e back to slower load times